### PR TITLE
don't include version numbers with OpenBSD

### DIFF
--- a/reload.lisp
+++ b/reload.lisp
@@ -21,19 +21,12 @@
 #+openbsd
 (progn
   (cffi:define-foreign-library libcrypto
-    (:openbsd (:or "libcrypto.so.22.0"
-                   "libcrypto.so.21.0"
-                   "libcrypto.so.20.1"
-                   "libcrypto.so.19.0"
-                   "libcrypto.so.18.0")))
+    (:openbsd "libcrypto.so"))
   (cffi:use-foreign-library libcrypto))
 
 (cffi:define-foreign-library libssl
   (:windows "libssl32.dll")
   (:darwin (:or "libssl.dylib" "/usr/lib/libssl.dylib"))
-  (:openbsd (:or "libssl.so.19.0"
-                 "libssl.so.18.0" "libssl.so.17.1"
-                 "libssl.so.16.0" "libssl.so.15.1"))
   (:solaris (:or "/lib/64/libssl.so"
                  "libssl.so.0.9.8" "libssl.so" "libssl.so.4"))
   ((and :unix (not :cygwin)) (:or "libssl.so.1.0.0"


### PR DESCRIPTION
Maintaining list of ever-changing version numbers is tedious so use plain library name.
Tested on OpenBSD-current with amd64 arch.
