### PR TITLE
use (cffi:null-pointer) instead of 0 in call to ssl-ctx-ctrl

### DIFF
--- a/streams.lisp
+++ b/streams.lisp
@@ -225,7 +225,7 @@
   (ssl-ctx-ctrl handle
 		+SSL_CTRL_MODE+
 		+SSL_MODE_ACCEPT_MOVING_WRITE_BUFFER+
-		0)
+		(cffi:null-pointer))
   socket)
 
 (defun install-key-and-cert (handle key certificate)


### PR DESCRIPTION
- the change from :long to :pointer requires that we use a proper null pointer instead of 0.
