### PR TITLE
ssl-ctx-set-cipher-list

### DIFF
--- a/ffi.lisp
+++ b/ffi.lisp
@@ -196,6 +196,14 @@
   (ssl ssl-pointer)
   (str :string)
   (type :int))
+(cffi:defcfun ("SSL_CTX_set_cipher_list" ssl-ctx-set-cipher-list%)
+    :int
+  (ctx :pointer)
+  (ciphers :pointer))
+(defun ssl-ctx-set-cipher-list (ctx ciphers)
+  (cffi:with-foreign-string (ciphers* ciphers)
+    (when (= 0 (ssl-ctx-set-cipher-list% ctx ciphers*))
+      (error 'ssl-error-initialize :reason "Can't set SSL cipher list" :queue (read-ssl-error-queue)))))
 (cffi:defcfun ("SSL_CTX_use_certificate_chain_file" ssl-ctx-use-certificate-chain-file)
     :int
   (ctx ssl-ctx)


### PR DESCRIPTION
Usage example:

```lisp
(ssl-ctx-set-cipher-list ssl-ctx
                         (format nil
                                 "ECDHE-RSA-AES256-GCM-SHA384:~
                                  ECDHE-RSA-AES256-SHA384:~
                                  ECDHE-RSA-AES256-SHA:~
                                  ECDHE-RSA-AES128-GCM-SHA256:~
                                  ECDHE-RSA-AES128-SHA256:~
                                  ECDHE-RSA-AES128-SHA:~
                                  ECDHE-RSA-RC4-SHA:~
                                  DHE-RSA-AES256-GCM-SHA384:~
                                  DHE-RSA-AES256-SHA256:~
                                  DHE-RSA-AES256-SHA:~
                                  DHE-RSA-AES128-GCM-SHA256:~
                                  DHE-RSA-AES128-SHA256:~
                                  DHE-RSA-AES128-SHA:~
                                  AES256-GCM-SHA384:~
                                  AES256-SHA256:~
                                  AES256-SHA:~
                                  AES128-GCM-SHA256:~
                                  AES128-SHA256:~
                                  AES128-SHA"))
```