### PR TITLE
Free *ssl-global-context* on reload

### DIFF
--- a/ffi.lisp
+++ b/ffi.lisp
@@ -594,6 +594,8 @@ context and in particular the loaded certificate chain."
   (ssl-ctx-use-certificate-chain-file *ssl-global-context* certificate-chain-file))
 
 (defun reload ()
+  (if *ssl-global-context*      
+      (ssl-ctx-free *ssl-global-context*))
   (cffi:load-foreign-library 'libssl)
   (cffi:load-foreign-library 'libeay32)
   (setf *ssl-global-context* nil)


### PR DESCRIPTION
ssl-ctx-free `ssl-global-context*` in `reload` 

`
SSL_CTX_free() decrements the reference count of ctx, and removes the SSL_CTX object pointed to by ctx and frees up the allocated memory if the the reference count has reached 0.
It also calls the free()ing procedures for indirectly affected items, if applicable: the session cache, the list of ciphers, the list of Client CAs, the certificates and keys.
`