### PR TITLE
Moving old tests to 5am

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,33 +1,28 @@
-language: lisp
+language: common-lisp
+sudo: false # lets try new infrastructure
 
 env:
+  global:
+    - PATH=~/.roswell/bin:$PATH
+    - ROSWELL_BRANCH=release
+    - ROSWELL_INSTALL_DIR=$HOME/.roswell
+    - COVERAGE_EXCLUDE=test
   matrix:
-    - LISP=abcl
-    - LISP=allegro
-    - LISP=sbcl
-    - LISP=sbcl32
-    - LISP=ccl
-    - LISP=ccl32
-    - LISP=clisp
-    - LISP=clisp32
-    - LISP=cmucl
-    - LISP=ecl
-
-matrix:
-  allow_failures:
-    # CIM not available for CMUCL
-    - env: LISP=cmucl
+    - LISP=sbcl-bin COVERALLS=true
 
 install:
-  - if [ -x ./install.sh ] && head -2 ./install.sh | grep '^# cl-travis' > /dev/null;
-    then
-      ./install.sh;
-    else
-      curl https://raw.githubusercontent.com/luismbo/cl-travis/master/install.sh | sh;
-    fi     
-        
-before_script:
-  # - echo "(defsystem :dummy-cl-travis-system)" > ~/lisp/dummy-cl-travis-system.asd
+  - curl -L https://raw.githubusercontent.com/snmsts/roswell/$ROSWELL_BRANCH/scripts/install-for-ci.sh | sh
+
+#  cache:
+#    directories:
+#      - $HOME/.roswell
+#      - $HOME/.config/common-lisp
 
 script:
-  - COVERALLS=true cl -e '(ql:quickload :cl+ssl.test) (let ((results (coveralls:with-coveralls (:exclude "test") (5am:run :cl+ssl)))) (5am:explain! results) (unless (5am:results-status results) (uiop:quit 1)))'
+  - ros -s cl+ssl.test
+        -e '(let ((results
+                    (coveralls:with-coveralls (:exclude "test")
+                      (5am:run :cl+ssl))))
+              (5am:explain! results)
+              (unless (5am:results-status results)
+                (uiop:quit 1)))'

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,6 +9,7 @@ env:
     - COVERAGE_EXCLUDE=test
   matrix:
     - LISP=sbcl-bin COVERALLS=true
+    - LISP=ccl-bin
 
 install:
   - curl -L https://raw.githubusercontent.com/snmsts/roswell/$ROSWELL_BRANCH/scripts/install-for-ci.sh | sh


### PR DESCRIPTION
Continue https://github.com/cl-plus-ssl/cl-plus-ssl/pull/29

I'm about to propose relatively huge changes, like moving all ffi stuff to separate package.
However I'm not feeling comfortable about this considering the fact I can not test anything. 
What I'm proposing:
- [x] Choose test framework (5AM)
- [x] Choose implemenation manager (Roswell)
- [x] Setup Travis CI environment
- [ ] Move old tests to 5am