### PR TITLE
optimize locking-callback

### DIFF
--- a/src/ffi.lisp
+++ b/src/ffi.lisp
@@ -594,7 +594,7 @@ will use this value.")
 (cffi:defcallback locking-callback :void
     ((mode :int)
      (n :int)
-     (file :string)
+     (file :pointer)
      (line :int))
   (declare (ignore file line))
   ;; (assert (logtest mode (logior +CRYPTO-READ+ +CRYPTO-WRITE+)))


### PR DESCRIPTION
Now each time it called (and this means REALLY frequently) cffi kindly converts foreign string to lisp for us. Given `file` not used it looks a bit redundant.