### PR TITLE
Use :long-long type at SSL_CTX_ctrl for 32bit environments.

### DIFF
--- a/src/ffi.lisp
+++ b/src/ffi.lisp
@@ -291,7 +291,7 @@ session-resume requests) would normally be copied into the local cache before pr
     :long
   (ctx ssl-ctx)
   (cmd :int)
-  (larg :long)
+  (larg :long-long)
   (parg :pointer))
 
 (cffi:defcfun ("SSL_ctrl" ssl-ctrl)


### PR DESCRIPTION
## Problem

On 32-bit environment, `CL+SSL:MAKE-CONTEXT` invokes a debugger:

```
? (cl+ssl:make-context)
> Error: The value 2181041151 is not of the expected type (SIGNED-BYTE 32).
> While executing: CL+SSL::SSL-CTX-CTRL, in process listener(1).
> Type :POP to abort, :R for a list of available restarts.
> Type :? for other options.
```

The type checking by CFFI failed because 2181041151 is not CFFI's :long type on 32-bit environments.

## Solution

The definition of `ssl-ctx-ctrl` which is called by `ssl-ctx-set-options` is here.

```
(cffi:defcfun ("SSL_CTX_ctrl" ssl-ctx-ctrl)
    :long
  (ctx ssl-ctx)
  (cmd :int)
  (larg :long)  ;; <= This type.
  (parg :pointer))
```

`(cffi:foreign-type-size :long)` returns 4 on 32-bit environments and perhaps it's small for `larg`.

Well, now, I'm a little bit confusing with that the [OpenSSL's document](https://www.openssl.org/docs/man1.0.2/ssl/SSL_CTX_ctrl.html) says the `larg` type is `long`.
However, changing the type to `:long-long` fixes this problem.