### PR TITLE
Fix SSL_OP_NO_SSLv2 constant value.

### DIFF
--- a/src/ffi.lisp
+++ b/src/ffi.lisp
@@ -85,7 +85,7 @@ session-resume requests) would normally be copied into the local cache before pr
 
 (defconstant +SSL-OP-ALL+ #x80000BFF)
 
-(defconstant +SSL-OP-NO-SSLv2+   #x00000000)
+(defconstant +SSL-OP-NO-SSLv2+   #x01000000)
 (defconstant +SSL-OP-NO-SSLv3+   #x02000000)
 (defconstant +SSL-OP-NO-TLSv1+   #x04000000)
 (defconstant +SSL-OP-NO-TLSv1-2+ #x08000000)


### PR DESCRIPTION
Without this set, Windows 7 systems connecting with the default
SSL_OP_NO_SSLv2 | SSL_OP_NO_SSLv3 options will effectively be using the
option SSL_OP_NO_SSLv3. According to a comment in the openssl source:

> SSL_OP_NO_X disables all protocols above X if there are some protocols below X enabled.

So in that case, we're essentially telling OpenSSL to /only/ use SSLv2,
which most servers won't allow at this point.

fixes #50