### PR TITLE
Remove the dependency on cl-coveralls on unsupported systems

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -33,7 +33,7 @@ script:
          -e '(ql:quickload :cl+ssl.test)'
          -e '(let ((results
                   #+ sbcl
-                  (coveralls:with-coveralls (:exclude "test")
+                  (coveralls:with-coveralls (:exclude \"test\")
                      (5am:run :cl+ssl))
                   #- sbcl
                   (5am:run :cl+ssl)))

--- a/.travis.yml
+++ b/.travis.yml
@@ -36,6 +36,8 @@ script:
                   (coveralls:with-coveralls (:exclude \"test\")
                      (5am:run :cl+ssl))
                   #- sbcl
-                  (5am:run :cl+ssl)))
+                  (5am:run :cl+ssl)
+                  ))
+              (5am:explain! results)
               (unless (5am:results-status results)
                 (uiop:quit 1)))'"

--- a/.travis.yml
+++ b/.travis.yml
@@ -32,8 +32,10 @@ script:
                (format t \"(asdf:asdf-version): ~A~%\" (asdf:asdf-version)))'
          -e '(ql:quickload :cl+ssl.test)'
          -e '(let ((results
-                  (coveralls:with-coveralls (:exclude \"test\")
-                     (5am:run :cl+ssl))))
-              (5am:explain! results)
+                  #+ sbcl
+                  (coveralls:with-coveralls (:exclude "test")
+                     (5am:run :cl+ssl))
+                  #- sbcl
+                  (5am:run :cl+ssl)))
               (unless (5am:results-status results)
                 (uiop:quit 1)))'"

--- a/cl+ssl.test.asd
+++ b/cl+ssl.test.asd
@@ -15,7 +15,7 @@
   :maintainer "Ilya Khaprov <ilya.khaprov@publitechs.com>"
   :author "Ilya Khaprov <ilya.khaprov@publitechs.com>"
   :licence "MIT"
-  :depends-on (:fiveam :cl-coveralls :cl+ssl :usocket)
+  :depends-on (:fiveam (:feature (:or :sbcl :ccl) :cl-coveralls) :cl+ssl :usocket)
   :serial t
   :components ((:module "test"
                 :serial t


### PR DESCRIPTION
With this the unit tests can be run on implementations not supported by cl-coveralls like Allegro CL.

__Tested with__

* Allegro CL 10.1
* SBCL 1.3.18