### PR TITLE
Add "libssl.so.1.0.2m" to the list of paths for UNIX.

### DIFF
--- a/src/reload.lisp
+++ b/src/reload.lisp
@@ -46,6 +46,7 @@
   ;; More info at https://github.com/cl-plus-ssl/cl-plus-ssl/pull/2.
   (:openbsd "libssl.so")
   ((and :unix (not :cygwin)) (:or "libssl.so.1.0.2"
+                                  "libssl.so.1.0.2m"
                                   "libssl.so.1.0.1l"
                                   "libssl.so.1.0.1e"
                                   "libssl.so.1.0.1j"


### PR DESCRIPTION
Even though I had OpenSSL 1.0 installed as per https://github.com/cl-plus-ssl/cl-plus-ssl/issues/43, version 1.1 was getting loaded because "libssl.so.1.0.2m" wasn't listed in the paths.