### PR TITLE
Honor the timeout setting of the underlying stream

### DIFF
--- a/index.html
+++ b/index.html
@@ -340,6 +340,23 @@
       random number generator has not been seeded with enough randomness to ensure 
       an unpredictable byte sequence.
     </p>
+    <p>
+      <div class="def">Generic function CL+SSL:STREAM-INPUT-TIMEOUT (stream)</div>
+      <div class="def">Generic function CL+SSL:STREAM-OUTPUT-TIMEOUT (stream)</div>
+      <div class="def">Generic function CL+SSL:STREAM-DEADLINE (stream) ; Only in Clozure </div>
+      Some Common Lisp implementations support setting a timeout on a stream
+      associated with a socket. These functions are used to extract timeouts
+      and deadlines from the stream object passed to
+      <tt>cl+ssl:make-ssl-server-stream</tt> or
+      <tt>cl+ssl:make-ssl-client-stream</tt>. If they return a number, CL+SSL
+      uses it to set up a timeout while waiting for the stream to be able to
+      process a complete chunk of encrypted data. When a timeout is fired, an
+      implementation defined error is raised. Currently supported
+      implementations are SBCL and Clozure. For SBCL, see the section
+      "Synchronous Timeouts (Deadlines)" in the user manual and the
+      documentation on <tt>sb-sys:wait-until-fd-usable</tt>; for Clozure see
+      the documentation section "Stream Timeouts and Deadlines".
+    </p>
 
     <h3>Portability</h3>
     <p>

--- a/src/package.lisp
+++ b/src/package.lisp
@@ -16,6 +16,10 @@
            #:ensure-initialized
            #:reload
            #:stream-fd
+           #:stream-input-timeout
+           #:stream-output-timeout
+           #+openmcl
+           #:stream-deadline
            #:make-ssl-client-stream
            #:*make-ssl-client-stream-verify-default*
            #:make-ssl-server-stream

--- a/src/streams.lisp
+++ b/src/streams.lisp
@@ -448,12 +448,41 @@ may be associated with the passphrase PASSWORD."
       (handle-external-format stream external-format))))
 
 #+openmcl
-(defmethod stream-deadline ((stream ccl::basic-stream))
-  (ccl::ioblock-deadline (ccl::stream-ioblock stream t)))
+(defgeneric stream-deadline (stream))
+
 #+openmcl
-(defmethod stream-deadline ((stream t))
+(defmethod stream-deadline (stream)
   nil)
 
+#+openmcl
+(defmethod stream-deadline ((stream ccl::basic-stream))
+  (ccl::ioblock-deadline (ccl::stream-ioblock stream t)))
+
+(defgeneric stream-input-timeout (stream))
+
+(defmethod stream-input-timeout (stream)
+  nil)
+
+#+openmcl
+(defmethod stream-input-timeout ((stream ccl::basic-stream))
+  (ccl::stream-input-timeout stream))
+
+#+sbcl
+(defmethod stream-input-timeout ((stream sb-sys:fd-stream))
+  (sb-impl::fd-stream-timeout stream))
+
+(defgeneric stream-output-timeout (stream))
+
+(defmethod stream-output-timeout (stream)
+  nil)
+
+#+openmcl
+(defmethod stream-output-timeout ((stream ccl::basic-stream))
+  (ccl::stream-output-timeout stream))
+
+#+sbcl
+(defmethod stream-output-timeout ((stream sb-sys:fd-stream))
+  (sb-impl::fd-stream-timeout stream))
 
 (defgeneric stream-fd (stream))
 (defmethod stream-fd (stream) stream)


### PR DESCRIPTION
Hunchentoot with an SSL acceptor and one thread per connection taskmaster results in stale threads on the server. This taskmaster handles each connection in its own thread. The thread opens a socket with the help of the acceptor, reads and processes the request and then waits with a specified timeout for possible further requests. The timeout is set when the socket is opened in an implementation defined way (see set-timeouts.lisp in the Hunchentoot code). In SBCL, the timeout is set by changing the value in the SB-SYS:FD-STREAM structure. CL+SSL wraps the SB-SYS:FD-STREAM returned by USOCKET with an SSL-STREAM which is then used for all input/output. In particular, when the thread waits for further requests, it ends up in the INPUT-WAIT function which calls SB-SYS:WAIT-UNTIL-FD-USABLE with TIMEOUT set to NIL. I'm not sure why, but it seems that if the connection is lost due to a network failure, the socket is never notified about it, and the thread just hangs forever.

ca79378 fixes that by using the timeout parameter of the underlying stream along with the deadline parameter of the SSL-STREAM to calculate the proper argument to SB-SYS:WAIT-UNTIL-FD-USABLE.

I don't know Clozure, so I didn't modify its branch of code, just made it look similar to SBCL.

That didn't solve the problem, however, because ENSURE-SSL-FUNCALL waits forever for the proper end of communication. I'm not sure what would be the best API to inform the caller about the timeout. 07650c4 makes ENSURE-SSL-FUNCALL to signal a TIMEOUT condition with a RETRY restart established.

The following code demonstrates the problem. If the client never ends communication, the server thread hangs forever. With the patches applied, it catches the TIMEOUT signal and terminates.

    #!/usr/bin/sbcl --script

    (eval-when (:compile-toplevel :load-toplevel :execute)
      (load #p"~/quicklisp/setup.lisp"))

    (eval-when (:compile-toplevel :load-toplevel :execute)
      (ql:quickload "usocket")
      (ql:quickload "cl+ssl"))

    (let ((timeout 2))
      (let (key certificate tmp)
        (setf key         (cadr  sb-ext:*posix-argv*)
              certificate (caddr sb-ext:*posix-argv*))
        (unless (and key certificate)
          (setf tmp         (sb-posix:mkdtemp "/tmp/cl+ssl-test.XXXXXX")
                key         (format nil "~a/key" tmp)
                certificate (format nil "~a/certificate" tmp))
          (sb-ext:run-program "openssl"
                              (list "req"
                                    "-x509"
                                    "-newkey" "rsa:512"
                                    "-keyout" key
                                    "-out"    certificate
                                    "-nodes"
                                    "-subj"   "/CN=localhost")
                              :search t
                              :output t))
        (unwind-protect
          (let ((server
                  (sb-thread:make-thread
                    (lambda ()
                      (handler-case
                        (usocket:with-server-socket (listener (usocket:socket-listen
                                                                "localhost" 26666))
                          (let ((client (usocket:socket-accept listener)))
                            ; see HUNCHENTOOT::SET-TIMEOUTS
                            (setf (sb-impl::fd-stream-timeout
                                    (usocket:socket-stream client))
                                  (coerce timeout 'single-float))
                            (let ((ssl (cl+ssl:make-ssl-server-stream
                                         (usocket:socket-stream client)
                                         :certificate certificate
                                         :key key)))
                              (let ((value (read-byte ssl)))
                                (format t "Got ~a~%" value)))))
                        #.(let ((cl+ssl-timeout (find-symbol "TIMEOUT" '#:cl+ssl)))
                            (when cl+ssl-timeout
                              `(,cl+ssl-timeout ()
                                  (format t "Timed out~%"))))))
                    :name "server")))
            (sleep 1)
            (usocket:with-client-socket (socket stream "localhost" 26666)
              (let ((ssl (cl+ssl:make-ssl-client-stream stream
                                                        :certificate certificate
                                                        :key key
                                                        :verify nil)))
                (format t "Awaiting timeout (~d seconds)~%" timeout)
                (sb-thread:join-thread server))))
          (when tmp
            (sb-posix:unlink key)
            (sb-posix:unlink certificate)
            (sb-posix:rmdir  tmp)))))