### PR TITLE
Support loading non-RSA private keys from files

### DIFF
--- a/src/ffi.lisp
+++ b/src/ffi.lisp
@@ -313,6 +313,17 @@ Note: the _really_ old formats (<= 0.9.4) are not supported."
     :int
   (ctx ssl-ctx)
   (type :int))
+(define-ssl-function ("SSL_use_PrivateKey_file" ssl-use-privatekey-file)
+  :int
+  (ssl ssl-pointer)
+  (str :string)
+  ;; either +ssl-filetype-pem+ or +ssl-filetype-asn1+
+  (type :int))
+(define-ssl-function
+    ("SSL_CTX_use_PrivateKey_file" ssl-ctx-use-privatekey-file)
+  :int
+  (ctx ssl-ctx)
+  (type :int))
 (define-ssl-function ("SSL_use_certificate_file" ssl-use-certificate-file)
     :int
   (ssl ssl-pointer)

--- a/src/streams.lisp
+++ b/src/streams.lisp
@@ -247,10 +247,10 @@
       (error 'ssl-error-initialize
        :reason (format nil "Can't load certificate ~A" certificate))))
   (when key
-    (unless (eql 1 (ssl-use-rsa-privatekey-file handle
+    (unless (eql 1 (ssl-use-privatekey-file handle
             key
             +ssl-filetype-pem+))
-      (error 'ssl-error-initialize :reason (format nil "Can't load RSA private key file ~A" key)))))
+      (error 'ssl-error-initialize :reason (format nil "Can't load private key file ~A" key)))))
 
 (defun x509-certificate-names (x509-certificate)
   (unless (cffi:null-pointer-p x509-certificate)


### PR DESCRIPTION
install-key-and-cert uses `SSL_use_RSAPrivateKey_file`, which handles only RSA
keys. `SSL_use_PrivateKey_file` has been available in OpenSSL since [at least
0.9.8](https://github.com/openssl/openssl/blob/OpenSSL_0_9_8-stable/doc/ssl/SSL_CTX_use_certificate.pod), and has broader algorithm support (e.g., ECDSA).

This adds the `SSL_use` and `SSL_CTX_use` versions of the broader functions,
just like the RSA-specific ones at the moment, and makes install-key-and-cert
use them. This does not remove the RSA-specific functions, to be safe against inadvertently breaking external users.