### PR TITLE
Export the SSL-STREAM-X509-CERTIFICATE function.

### DIFF
--- a/src/package.lisp
+++ b/src/package.lisp
@@ -61,6 +61,7 @@
            ;; x509 stuff
            #:decode-certificate-from-file
            #:decode-certificate
+           #:ssl-stream-x509-certificate
 
            ;; hostname-verification
            #:verify-hostname))


### PR DESCRIPTION
This is needed to check the remote's identity via hunchentoot.