### PR TITLE
Don't load undefined libeay32 foreign-library.

### DIFF
--- a/src/ffi.lisp
+++ b/src/ffi.lisp
@@ -995,8 +995,7 @@ context and in particular the loaded certificate chain."
   (unless (member :cl+ssl-foreign-libs-already-loaded
                   *features*)
     (cffi:use-foreign-library libcrypto)
-    (cffi:load-foreign-library 'libssl)
-    (cffi:load-foreign-library 'libeay32))
+    (cffi:load-foreign-library 'libssl))
   (setf *ssl-global-context* nil)
   (setf *ssl-global-method* nil)
   (setf *tmp-rsa-key-512* nil)


### PR DESCRIPTION
In commit 5860d85a8d3224b555e092b010a3bd6d7e818f31, a new foreign library named `libeay32` was defined
and added to the reload function. 1f2c1ed66e9ac273d5f71f40142249e989f70054 removed the `libeay32`
foreign-library in favor of using an alternate dll name for the `libssl`
library, but `libeay32` is still loaded in the `reload` function, which causes
an "undefined foreign library" error when `reload` is called.