### PR TITLE
Un-break LibreSSL

### DIFF
--- a/src/ffi.lisp
+++ b/src/ffi.lisp
@@ -282,6 +282,8 @@ Note: the _really_ old formats (<= 0.9.4) are not supported."
     :void)
 (define-ssl-function-ex (:vanished "1.1.0") ("SSL_library_init" ssl-library-init)
     :int)
+(define-ssl-function-ex (:since "1.1.0") ("OPENSSL_init_ssl" openssl-init-ssl)
+    :int)
 ;;
 ;; We don't refer SSLv2_client_method as the default
 ;; builds of OpenSSL do not have it, due to insecurity
@@ -931,28 +933,32 @@ MAKE-CONTEXT also allows to enab/disable verification.")
       'ssl-v23-method))
 
 (defun initialize (&key method rand-seed)
-  (when (openssl-is-not-even 1 1)
-    (setf *locks* (loop
-                     repeat (crypto-num-locks)
-                     collect (bt:make-lock)))
-    (crypto-set-locking-callback (cffi:callback locking-callback))
-    (crypto-set-id-callback (cffi:callback threadid-callback))
-    (ssl-load-error-strings)
-    (ssl-library-init))
-  (setf *bio-lisp-method* (make-bio-lisp-method))
-  (when rand-seed
-    (init-prng rand-seed))
-  (setf *ssl-check-verify-p* :unspecified)
-  (setf *ssl-global-method* (funcall (or method (default-ssl-method))))
-  (setf *ssl-global-context* (ssl-ctx-new *ssl-global-method*))
-  (unless (eql 1 (ssl-ctx-set-default-verify-paths *ssl-global-context*))
-    (error "ssl-ctx-set-default-verify-paths failed."))
-  (ssl-ctx-set-session-cache-mode *ssl-global-context* 3)
-  (ssl-ctx-set-default-passwd-cb *ssl-global-context*
-                                 (cffi:callback pem-password-callback))
-  (when (openssl-is-not-even 1 1)
-    (ssl-ctx-set-tmp-rsa-callback *ssl-global-context*
-                                  (cffi:callback tmp-rsa-callback))))
+  (let ((api-11 (and (openssl-is-at-least 1 1)
+                     (not (libresslp)))))
+    (if api-11
+        (openssl-init-ssl)
+        (ssl-library-init))
+    (unless api-11
+      (setf *locks* (loop
+                       repeat (crypto-num-locks)
+                       collect (bt:make-lock)))
+      (crypto-set-locking-callback (cffi:callback locking-callback))
+      (crypto-set-id-callback (cffi:callback threadid-callback))
+      (ssl-load-error-strings))
+    (setf *bio-lisp-method* (make-bio-lisp-method))
+    (when rand-seed
+      (init-prng rand-seed))
+    (setf *ssl-check-verify-p* :unspecified)
+    (setf *ssl-global-method* (funcall (or method (default-ssl-method))))
+    (setf *ssl-global-context* (ssl-ctx-new *ssl-global-method*))
+    (unless (eql 1 (ssl-ctx-set-default-verify-paths *ssl-global-context*))
+      (error "ssl-ctx-set-default-verify-paths failed."))
+    (ssl-ctx-set-session-cache-mode *ssl-global-context* 3)
+    (ssl-ctx-set-default-passwd-cb *ssl-global-context*
+                                   (cffi:callback pem-password-callback))
+    (unless api-11
+      (ssl-ctx-set-tmp-rsa-callback *ssl-global-context*
+                                    (cffi:callback tmp-rsa-callback)))))
 
 (defun ensure-initialized (&key method (rand-seed nil))
   "In most cases you do *not* need to call this function, because it


### PR DESCRIPTION
Commit d3e4424 addressing issue #64 caused code paths necessary for the
correct functioning of LibreSSL to be skipped. In particular:
 - Locking callbacks are no longer set, causing crashes when CL+SSL
   is used in an application with multiple threads.
 - SSL_library_init and SSL_load_error_strings are no longer called.
 - SSL_CTX_set_tmp_rsa_callback is no longer called (probably harmless,
   as this is only relevant if one is using export grade ciphersuites).

This was an easy to make oversight. The code paths above are
predicated on COMPAT-OPENSSL-VERSION being below version 1.1, since
they are no longer necessary for versions 1.1 or later. However,
LibreSSL APIs are compatible with version OpenSSL 1.0 APIs, yet the
version number is encoded as 2.0 (technically, #x20000000).

This change updates the conditional using LIBRESSLP, so that the
necessary code paths are restored. Additionally, it adds
OPENSSL-INIT-SSL and conditionally calls it instead of
SSL-INIT-LIBRARY for OpenSSL 1.1, where OPENSSL_init_ssl supersedes
SSL_library_init and SSL_load_error_strings.