### PR TITLE
make it work with readtable-case :invert

### DIFF
--- a/src/ffi.lisp
+++ b/src/ffi.lisp
@@ -170,42 +170,42 @@ variants if you have use cases for them.)"
 (defconstant +ssl-filetype-asn1+ 2)
 (defconstant +ssl-filetype-default+ 3)
 
-(defconstant +SSL-CTRL-OPTIONS+ 32)
-(defconstant +SSL_CTRL_SET_SESS_CACHE_MODE+ 44)
-(defconstant +SSL_CTRL_MODE+ 33)
+(defconstant +ssl-ctrl-options+ 32)
+(defconstant +ssl_ctrl_set_sess_cache_mode+ 44)
+(defconstant +ssl_ctrl_mode+ 33)
 
-(defconstant +SSL_MODE_ACCEPT_MOVING_WRITE_BUFFER+ 2)
+(defconstant +ssl_mode_accept_moving_write_buffer+ 2)
 
-(defconstant +RSA_F4+ #x10001)
+(defconstant +rsa_f4+ #x10001)
 
-(defconstant +SSL-SESS-CACHE-OFF+ #x0000
+(defconstant +ssl-sess-cache-off+ #x0000
   "No session caching for client or server takes place.")
-(defconstant +SSL-SESS-CACHE-CLIENT+ #x0001
+(defconstant +ssl-sess-cache-client+ #x0001
   "Client sessions are added to the session cache.
 As there is no reliable way for the OpenSSL library to know whether a session should be reused
 or which session to choose (due to the abstract BIO layer the SSL engine does not have details
 about the connection), the application must select the session to be reused by using the
 SSL-SET-SESSION function. This option is not activated by default.")
-(defconstant +SSL-SESS-CACHE-SERVER+ #x0002
+(defconstant +ssl-sess-cache-server+ #x0002
   "Server sessions are added to the session cache.
 When a client proposes a session to be reused, the server looks for the corresponding session
 in (first) the internal session cache (unless +SSL-SESS-CACHE-NO-INTERNAL-LOOKUP+ is set), then
 (second) in the external cache if available. If the session is found, the server will try to
 reuse the session. This is the default.")
-(defconstant +SSL-SESS-CACHE-BOTH+ (logior +SSL-SESS-CACHE-CLIENT+ +SSL-SESS-CACHE-SERVER+)
+(defconstant +ssl-sess-cache-both+ (logior +ssl-sess-cache-client+ +ssl-sess-cache-server+)
   "Enable both +SSL-SESS-CACHE-CLIENT+ and +SSL-SESS-CACHE-SERVER+ at the same time.")
-(defconstant +SSL-SESS-CACHE-NO-AUTO-CLEAR+ #x0080
+(defconstant +ssl-sess-cache-no-auto-clear+ #x0080
   "Normally the session cache is checked for expired sessions every 255 connections using the
 SSL-CTX-FLUSH-SESSIONS function. Since this may lead to a delay which cannot be controlled,
 the automatic flushing may be disabled and SSL-CTX-FLUSH-SESSIONS can be called explicitly
 by the application.")
-(defconstant +SSL-SESS-CACHE-NO-INTERNAL-LOOKUP+ #x0100
+(defconstant +ssl-sess-cache-no-internal-lookup+ #x0100
   "By setting this flag, session-resume operations in an SSL/TLS server will not automatically
 look up sessions in the internal cache, even if sessions are automatically stored there.
 If external session caching callbacks are in use, this flag guarantees that all lookups are
 directed to the external cache. As automatic lookup only applies for SSL/TLS servers, the flag
 has no effect on clients.")
-(defconstant +SSL-SESS-CACHE-NO-INTERNAL-STORE+ #x0200
+(defconstant +ssl-sess-cache-no-internal-store+ #x0200
   "Depending on the presence of +SSL-SESS-CACHE-CLIENT+ and/or +SSL-SESS-CACHE-SERVER+, sessions
 negotiated in an SSL/TLS handshake may be cached for possible reuse. Normally a new session is
 added to the internal cache as well as any external session caching (callback) that is configured
@@ -214,21 +214,21 @@ application can add them manually using SSL-CTX-ADD-SESSION). Note: in any SSL/T
 external caching is configured, any successful session lookups in the external cache (ie. for
 session-resume requests) would normally be copied into the local cache before processing continues
 - this flag prevents these additions to the internal cache as well.")
-(defconstant +SSL-SESS-CACHE-NO-INTERNAL+ (logior +SSL-SESS-CACHE-NO-INTERNAL-LOOKUP+ +SSL-SESS-CACHE-NO-INTERNAL-STORE+)
+(defconstant +ssl-sess-cache-no-internal+ (logior +ssl-sess-cache-no-internal-lookup+ +ssl-sess-cache-no-internal-store+)
   "Enable both +SSL-SESS-CACHE-NO-INTERNAL-LOOKUP+ and +SSL-SESS-CACHE-NO-INTERNAL-STORE+ at the same time.")
 
-(defconstant +SSL-VERIFY-NONE+ #x00)
-(defconstant +SSL-VERIFY-PEER+ #x01)
-(defconstant +SSL-VERIFY-FAIL-IF-NO-PEER-CERT+ #x02)
-(defconstant +SSL-VERIFY-CLIENT-ONCE+ #x04)
+(defconstant +ssl-verify-none+ #x00)
+(defconstant +ssl-verify-peer+ #x01)
+(defconstant +ssl-verify-fail-if-no-peer-cert+ #x02)
+(defconstant +ssl-verify-client-once+ #x04)
 
-(defconstant +SSL-OP-ALL+ #x80000BFF)
+(defconstant +ssl-op-all+ #x80000bff)
 
-(defconstant +SSL-OP-NO-SSLv2+   #x01000000)
-(defconstant +SSL-OP-NO-SSLv3+   #x02000000)
-(defconstant +SSL-OP-NO-TLSv1+   #x04000000)
-(defconstant +SSL-OP-NO-TLSv1-2+ #x08000000)
-(defconstant +SSL-OP-NO-TLSv1-1+ #x10000000)
+(defconstant +ssl-op-no-sslv2+   #x01000000)
+(defconstant +ssl-op-no-sslv3+   #x02000000)
+(defconstant +ssl-op-no-tlsv1+   #x04000000)
+(defconstant +ssl-op-no-tlsv1-2+ #x08000000)
+(defconstant +ssl-op-no-tlsv1-1+ #x10000000)
 
 (defvar *tmp-rsa-key-512* nil)
 (defvar *tmp-rsa-key-1024* nil)
@@ -599,27 +599,27 @@ Note: the _really_ old formats (<= 0.9.4) are not supported."
   (len :int))
 
 ;; GENERAL-NAME types
-(defconstant +GEN-OTHERNAME+  0)
-(defconstant +GEN-EMAIL+  1)
-(defconstant +GEN-DNS+    2)
-(defconstant +GEN-X400+ 3)
-(defconstant +GEN-DIRNAME+  4)
-(defconstant +GEN-EDIPARTY+ 5)
-(defconstant +GEN-URI+    6)
-(defconstant +GEN-IPADD+  7)
-(defconstant +GEN-RID+    8)
+(defconstant +gen-othername+  0)
+(defconstant +gen-email+  1)
+(defconstant +gen-dns+    2)
+(defconstant +gen-x400+ 3)
+(defconstant +gen-dirname+  4)
+(defconstant +gen-ediparty+ 5)
+(defconstant +gen-uri+    6)
+(defconstant +gen-ipadd+  7)
+(defconstant +gen-rid+    8)
 
-(defconstant +V-ASN1-OCTET-STRING+ 4)
-(defconstant +V-ASN1-UTF8STRING+ 12)
-(defconstant +V-ASN1-PRINTABLESTRING+ 19)
-(defconstant +V-ASN1-TELETEXSTRING+ 20)
-(defconstant +V-ASN1-IASTRING+ 22)
-(defconstant +V-ASN1-UNIVERSALSTRING+ 28)
-(defconstant +V-ASN1-BMPSTRING+ 30)
+(defconstant +v-asn1-octet-string+ 4)
+(defconstant +v-asn1-utf8string+ 12)
+(defconstant +v-asn1-printablestring+ 19)
+(defconstant +v-asn1-teletexstring+ 20)
+(defconstant +v-asn1-iastring+ 22)
+(defconstant +v-asn1-universalstring+ 28)
+(defconstant +v-asn1-bmpstring+ 30)
 
 
-(defconstant +NID-subject-alt-name+ 85)
-(defconstant +NID-commonName+   13)
+(defconstant +nid-subject-alt-name+ 85)
+(defconstant +nid-commonname+   13)
 
 (cffi:defcstruct general-name
   (type :int)
@@ -898,10 +898,10 @@ will use this value.")
   (ssl-ctrl ctx 55 #|SSL_CTRL_SET_TLSEXT_HOSTNAME|# 0 #|TLSEXT_NAMETYPE_host_name|# hostname))
 
 (defvar *locks*)
-(defconstant +CRYPTO-LOCK+ 1)
-(defconstant +CRYPTO-UNLOCK+ 2)
-(defconstant +CRYPTO-READ+ 4)
-(defconstant +CRYPTO-WRITE+ 8)
+(defconstant +crypto-lock+ 1)
+(defconstant +crypto-unlock+ 2)
+(defconstant +crypto-read+ 4)
+(defconstant +crypto-write+ 8)
 
 ;; zzz as of early 2011, bxthreads is totally broken on SBCL wrt. explicit
 ;; locking of recursive locks.  with-recursive-lock works, but acquire/release


### PR DESCRIPTION

Hi cl+ssl maintainers,

I hope you can accept this patch, downcasing constant names in ffi.lisp to make things work with different readtable-case settings such as :invert. 

Sorry it messes with the nice source code style of having constants in uppercase. 

Thanks,

 Dave

 
