### PR TITLE
Restore loading on non-ABCL implementations

### DIFF
--- a/src/streams.lisp
+++ b/src/streams.lisp
@@ -502,8 +502,9 @@ may be associated with the passphrase PASSWORD."
                        (jss:get-java-field x y t))
                      fields
                      :initial-value object)))
-      (ignore-errors 
-       (get-java-fields (#"getWrappedInputStream" (two-way-stream-input-stream stream))
+      (ignore-errors
+       (get-java-fields (java:jcall "getWrappedInputStream"  ;; TODO: define this as a constant
+                                    (two-way-stream-input-stream stream))
                         '("in" "ch" "fdVal"))))))
 
 


### PR DESCRIPTION
Mea culpa on the fact that the reader still reads the forms under
```cl:*features*``` conditionals regardless of their evaluation status.

FIxes <https://github.com/cl-plus-ssl/cl-plus-ssl/issues/99>