### PR TITLE
Fix automatic newline conversion to CRLF by Git

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -8,4 +8,4 @@
 # And it general, I don't like any magic conversions. Better
 # to work with files as they are.
 
-* text=false
+* -text


### PR DESCRIPTION
Although the current `.gitattributes` file is intended to achieve
this, by bypassing any local definition, the current definition does not
work due to some unintended effects.

As per Git's
documentation (https://git-scm.com/docs/gitattributes#_description),
an attribute can have one of four states: Set, Unset, Set to a value,
Unspecified.
This, in addition to the documentation of the text
attribute (https://git-scm.com/docs/gitattributes#_text), dictate
that the current specification gets git to consider the text attribute
as Unspecified, where the value of `core.autocrlf` will be used.

This commit corrects the attribute text, which will force Git
to not attempt any line ending conversions on checkin or checkout.

I believe that setting the attribute text to the string value of "false" would achieve the same result, but I have not tested that.