### PR TITLE
use versioned dylib path for libcrypto on macOS

### DIFF
--- a/src/reload.lisp
+++ b/src/reload.lisp
@@ -46,10 +46,9 @@
                 "/usr/local/opt/openssl/lib/libcrypto.dylib" ;; Homebrew
                 "/usr/local/lib/libcrypto.dylib" ;; personalized install
                 ;; System-provided libraries. Please note that in macOS >= 11.0,
-                ;; these paths may not exist in the file system anymore, but
-                ;; trying to load them via dlopen will work. This is because
-                ;; macOS ships all system-provided libraries as a
-                ;; single 'dyld cache' bundle.
+                ;; these paths may not exist in the file system anymore, but trying
+                ;; to load them via dlopen will work. This is because macOS ships
+                ;; all system-provided libraries as a single dyld_shared_cache bundle.
                 "/usr/lib/libcrypto.44.dylib"
                 "/usr/lib/libcrypto.42.dylib"
                 "/usr/lib/libcrypto.41.dylib"

--- a/src/reload.lisp
+++ b/src/reload.lisp
@@ -45,8 +45,11 @@
                 "/sw/lib/libcrypto.dylib"        ;; Fink
                 "/usr/local/opt/openssl/lib/libcrypto.dylib" ;; Homebrew
                 "/usr/local/lib/libcrypto.dylib" ;; personalized install
-                "libcrypto.dylib"                ;; default system libcrypto, which may have insufficient crypto
-                "/usr/lib/libcrypto.dylib"))
+                ;; system-provided libraries
+                "/usr/lib/libcrypto.44.dylib"
+                "/usr/lib/libcrypto.42.dylib"
+                "/usr/lib/libcrypto.41.dylib"
+                "/usr/lib/libcrypto.35.dylib"))
   (:cygwin (:or "cygcrypto-1.1.dll" "cygcrypto-1.0.0.dll")))
 
 (cffi:define-foreign-library libssl
@@ -62,8 +65,11 @@
                 "/sw/lib/libssl.dylib"        ;; Fink
                 "/usr/local/opt/openssl/lib/libssl.dylib" ;; Homebrew
                 "/usr/local/lib/libssl.dylib" ;; personalized install
-                "libssl.dylib"                ;; default system libssl, which may have insufficient crypto
-                "/usr/lib/libssl.dylib"))
+                ;; system-provided libraries
+                "/usr/lib/libssl.46.dylib"
+                "/usr/lib/libssl.44.dylib"
+                "/usr/lib/libssl.43.dylib"
+                "/usr/lib/libssl.35.dylib"))
   (:solaris (:or "/lib/64/libssl.so"
                  "libssl.so.0.9.8" "libssl.so" "libssl.so.4"))
   ;; Unlike some other systems, OpenBSD linker,

--- a/src/reload.lisp
+++ b/src/reload.lisp
@@ -45,7 +45,11 @@
                 "/sw/lib/libcrypto.dylib"        ;; Fink
                 "/usr/local/opt/openssl/lib/libcrypto.dylib" ;; Homebrew
                 "/usr/local/lib/libcrypto.dylib" ;; personalized install
-                ;; system-provided libraries
+                ;; System-provided libraries. Please note that in macOS >= 11.0,
+                ;; these paths may not exist in the file system anymore, but
+                ;; trying to load them via dlopen will work. This is because
+                ;; macOS ships all system-provided libraries as a
+                ;; single 'dyld cache' bundle.
                 "/usr/lib/libcrypto.44.dylib"
                 "/usr/lib/libcrypto.42.dylib"
                 "/usr/lib/libcrypto.41.dylib"
@@ -65,7 +69,7 @@
                 "/sw/lib/libssl.dylib"        ;; Fink
                 "/usr/local/opt/openssl/lib/libssl.dylib" ;; Homebrew
                 "/usr/local/lib/libssl.dylib" ;; personalized install
-                ;; system-provided libraries
+                ;; System-provided libraries. See note about libcrypto.*.dylib above.
                 "/usr/lib/libssl.46.dylib"
                 "/usr/lib/libssl.44.dylib"
                 "/usr/lib/libssl.43.dylib"

--- a/src/reload.lisp
+++ b/src/reload.lisp
@@ -45,10 +45,13 @@
                 "/sw/lib/libcrypto.dylib"        ;; Fink
                 "/usr/local/opt/openssl/lib/libcrypto.dylib" ;; Homebrew
                 "/usr/local/lib/libcrypto.dylib" ;; personalized install
-                ;; System-provided libraries. Please note that in macOS >= 11.0,
-                ;; these paths may not exist in the file system anymore, but trying
-                ;; to load them via dlopen will work. This is because macOS ships
-                ;; all system-provided libraries as a single dyld_shared_cache bundle.
+                ;; System-provided libraries. These must be loaded with an explicit
+                ;; API version, or else the process will crash.
+                ;;
+                ;; Please note that in macOS >= 11.0, these paths may not exist in the
+                ;; file system anymore, but trying to load them via dlopen will work. This
+                ;; is because macOS ships all system-provided libraries as a single
+                ;; dyld_shared_cache bundle.
                 "/usr/lib/libcrypto.44.dylib"
                 "/usr/lib/libcrypto.42.dylib"
                 "/usr/lib/libcrypto.41.dylib"


### PR DESCRIPTION
In macOS 11, libcrypto.dylib provided by Apple will crash the process
when loading it, saying that it is being loaded in an "unsafe way". Loading
a specific version of the library explicitly is fine, and does not cause
this issue.

Fixes #114 