### PR TITLE
Add :canary to cffi:define-foreign-library

### DIFF
--- a/src/reload.lisp
+++ b/src/reload.lisp
@@ -36,7 +36,7 @@
 ;;
 ;; These are 32-bit only.
 
-(cffi:define-foreign-library libcrypto
+(cffi:define-foreign-library (libcrypto :canary "BIO_new")
   (:windows (:or #+(and windows x86-64) "libcrypto-1_1-x64.dll"
                  #+(and windows x86) "libcrypto-1_1.dll"
                  "libeay32.dll"))
@@ -75,7 +75,7 @@
                 "/usr/lib/libcrypto.dylib"))
   (:cygwin (:or "cygcrypto-1.1.dll" "cygcrypto-1.0.0.dll")))
 
-(cffi:define-foreign-library libssl
+(cffi:define-foreign-library (libssl :canary "SSL_connect")
   (:windows (:or #+(and windows x86-64) "libssl-1_1-x64.dll"
                  #+(and windows x86) "libssl-1_1.dll"
                  "libssl32.dll"


### PR DESCRIPTION
See
https://common-lisp.net/project/cffi/manual/cffi-manual.html#define_002dforeign_002dlibrary

This is CFFI's more general solution to pushing
`:cl+ssl-foreign-libs-already-loaded` to `*features*`. Supporting this is nice
as it requires zero work from the user.

I tried to choose symbols that appear to be present in all versions of
OpenSSL. If one of these symbols ever disappears, the canary should be updated.