### PR TITLE
SNI server-side support

### DIFF
--- a/src/context.lisp
+++ b/src/context.lisp
@@ -96,6 +96,8 @@
                           (verify-mode +ssl-verify-peer+)
                           (verify-callback nil verify-callback-supplied-p)
                           (cipher-list +default-cipher-list+)
+                          (sni nil)
+                          (sni-callback 'sni-callback)
                           (pem-password-callback 'pem-password-callback))
   (ensure-initialized)
   (let ((ctx (ssl-ctx-new (if method-supplied-p
@@ -134,6 +136,8 @@
                                                       (cffi:callback verify-peer-callback)
                                                       (cffi:null-pointer)))))
       (ssl-ctx-set-cipher-list ctx cipher-list)
+      (when (and sni sni-callback)
+        (ssl-ctx-set-tlsext-servername-callback ctx (cffi:get-callback sni-callback)))
       (ssl-ctx-set-default-passwd-cb ctx (cffi:get-callback pem-password-callback))
       ctx)))
 

--- a/src/package.lisp
+++ b/src/package.lisp
@@ -55,6 +55,11 @@
            #:+ssl-sess-cache-no-internal-store+
            #:+ssl-sess-cache-no-internal+
 
+           #:+ssl-tlsext-err-ok+
+           #:+ssl-tlsext-err-err-alert-warning+
+           #:+ssl-tlsext-err-err-alert-fatal+
+           #:+ssl-tlsext-err-err-noack+
+
            #:make-context
            #:with-global-context
 

--- a/src/streams.lisp
+++ b/src/streams.lisp
@@ -426,17 +426,19 @@ hostname verification if verification is enabled by VERIFY."
 (defun make-ssl-server-stream
     (socket &key certificate key password method external-format
                  close-callback (unwrap-stream-p t)
+                 sni-config
                  (cipher-list *default-cipher-list*))
   "Returns an SSL stream for the server socket descriptor SOCKET.
 CERTIFICATE is the path to a file containing the PEM-encoded certificate for
  your server. KEY is the path to the PEM-encoded key for the server, which
 may be associated with the passphrase PASSWORD."
   (ensure-initialized :method method)
-  (let ((stream (make-instance 'ssl-server-stream
-                               :socket socket
-                               :close-callback close-callback
-                               :certificate certificate
-                               :key key)))
+  (let* ((stream (make-instance 'ssl-server-stream
+                                :socket socket
+                                :close-callback close-callback
+                                :certificate certificate
+                                :key key))
+         (*sni-config* sni-config))
     (with-new-ssl (handle)
       (setf socket (install-handle-and-bio stream handle socket unwrap-stream-p))
       (ssl-set-accept-state handle)


### PR DESCRIPTION
Add support for handling SNI on the server. The ffi functions for working with the
SNI callback have been added, and a default callback has been defined. If `:sni t` is
passed to `make-context`, the default callback is registered. The callback can be
manually specified when calling `make-context` by using the `:sni-callback`
key.

When calling `make-ssl-server-stream`, an alist for SNI configuration can be passed
using the `:sni-config` key. The alist has the following structure:

```lisp
  ((server-name-str . ((:certificate certificate-path
                        :key key-path
                        :passphrase passphrase-str)))))
```

If a servername is passed in the TLS handshake and the default callback has been
registered, the servername will be looked up in the sni-config. If a value is
present, the certificate and key for the SNI entry are set on the SSL object. If
no value is present, SSL_TLSEXT_ERR_NOACK is returned and the server will continue
with the :certificate and :key passed into `make-ssl-server-stream`.