### PR TITLE
Increase CL-internal buffer size for SSL.

### DIFF
--- a/src/ffi-buffer-all.lisp
+++ b/src/ffi-buffer-all.lisp
@@ -4,7 +4,7 @@
 
 (in-package :cl+ssl)
 
-(defconstant +initial-buffer-size+ 2048)
+(defconstant +initial-buffer-size+ 131072)
 
 (declaim
  (inline


### PR DESCRIPTION
The default value is much too small - it causes too many (unnecessary)
syscalls and so increases latency quite a lot because of additional
threads scheduling.

With the old value of 2K and a real-world quux-hunchentoot easy-handler
that takes about 20msec to create a ~220kB output:

    Running 15s test @ https://localhost:8070/...
      3 threads and 3 connections
      Thread Stats   Avg      Stdev     Max   +/- Stdev
        Latency    71.09ms   22.98ms 183.60ms   80.96%
        Req/Sec    14.30      5.76    30.00     95.19%
      Latency Distribution
         50%   68.34ms
         75%   76.21ms
         90%   91.75ms
         99%  163.99ms
      637 requests in 15.03s, 142.58MB read
    Requests/sec:     42.37
    Transfer/sec:      9.48MB

With `+INITIAL-BUFFER-SIZE+` set higher:

    Running 15s test @ https://localhost:8070/...
      3 threads and 3 connections
      Thread Stats   Avg      Stdev     Max   +/- Stdev
        Latency    39.89ms   21.91ms 151.72ms   75.78%
        Req/Sec    25.35      7.16    60.00     89.06%
      Latency Distribution
         50%   28.86ms
         75%   61.30ms
         90%   67.58ms
         99%   96.53ms
      1140 requests in 15.03s, 255.74MB read
    Requests/sec:     75.85
    Transfer/sec:     17.02MB

Sadly openssl by default uses a 16kB buffer, so there are still
16 `write()` requests on the socket; perhaps the SSL socket buffer size
should be synchronized to `+INITIAL-BUFFER-SIZE+` via `BIO_ctrl`
(`bio-set-fd` in `cl+ssl`) and `BIO_C_SET_BUFF_SIZE` (currently not
available)?

As the content has to be generated in one go (no streaming data!)
any streaming/latency considerations don't apply here; but I guess it
would be much better to change the constant to a special, so that
tuning on a per-socket acceptor base is easily done.