### PR TITLE
Send shutdown alert to peer when closing SSL stream.

### DIFF
--- a/src/streams.lisp
+++ b/src/streams.lisp
@@ -85,6 +85,7 @@
     ((ssl-stream-handle stream)
      (unless abort
        (force-output stream))
+     (ssl-shutdown (ssl-stream-handle stream))
      (ssl-free (ssl-stream-handle stream))
      (setf (ssl-stream-handle stream) nil)
      (when (streamp (ssl-stream-socket stream))


### PR DESCRIPTION
Right now, closing an `ssl-stream` doesn't call `SSL_shutdown()`, resulting in a connection that is "non-properly terminated" according to clients such as `gnutls-cli`.