### PR TITLE
Fix return type of `ssl-shutdown`.

### DIFF
--- a/src/ffi.lisp
+++ b/src/ffi.lisp
@@ -398,7 +398,7 @@ Note: the _really_ old formats (<= 0.9.4) are not supported."
   (buf :pointer)
   (num :int))
 (define-ssl-function ("SSL_shutdown" ssl-shutdown)
-    :void
+    :int
   (ssl ssl-pointer))
 (define-ssl-function ("SSL_free" ssl-free)
     :void


### PR DESCRIPTION
The foreign function `SSL_shutdown()` returns an `int`, not `void`.