### PR TITLE
Fix tests on ABCL

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -135,11 +135,10 @@ script:
                 (format t \"abcl-asdf::*default-repository* assigned the HTTPS URL.~%\"))'
          -e '(ql:quickload :cffi)'
          -e '(format t \"cffi loaded.~%\")'
-         -e '(cffi:load-foreign-library \"test/run-on-many-lisps-and-openssls/openssl-releases/bin/'$OPENSSL-${BITS}bit'/lib/libcrypto.so\")'
-         -e '(format t \"libcrypto.so loaded.~%\")'
-         -e '(cffi:load-foreign-library \"test/run-on-many-lisps-and-openssls/openssl-releases/bin/'$OPENSSL-${BITS}bit'/lib/libssl.so\")'
-         -e '(format t \"libssl.so loaded.~%\")'
-         -e '(pushnew :cl+ssl-foreign-libs-already-loaded *features*)'
+         -e '(ql:quickload :cl+ssl/config)'
+         -e '(format t \"cl+ssl/config loaded.~%\")'
+         -e '(cl+ssl:define-libcrypto-path \"test/run-on-many-lisps-and-openssls/openssl-releases/bin/'$OPENSSL-${BITS}bit'/lib/libcrypto.so\")'
+         -e '(cl+ssl:define-libssl-path \"test/run-on-many-lisps-and-openssls/openssl-releases/bin/'$OPENSSL-${BITS}bit'/lib/libssl.so\")'
          -e '(ql:quickload :cl+ssl) ;; load cl+ssl separately from cl+ssl.test only because cl+ssl.test can not be loaded in the :invert readtable-case due to its dependency ironclad, as of 2019-10-20'
          -e '(format t \"cl+ssl loaded.~%\")'
          -e '(when (uiop:getenvp \"READTABLE_CASE_INVERT\")
@@ -155,23 +154,5 @@ script:
                   (5am:run :cl+ssl)
                   ))
               (5am:explain! results)
-              #+abcl
-              (let* ((expected-failures (quote (cl+ssl.test::wrong.host
-                                                cl+ssl.test::expired
-                                                cl+ssl.test::fingerprint-google-cert)))
-                     (failed-test-names (mapcar (lambda (result)
-                                                  (5am::name (5am::test-case result)))
-                                                (remove-if-not (quote 5am::test-failure-p)
-                                                               results))))
-                (if (set-exclusive-or expected-failures
-                                      failed-test-names)
-                    (progn
-                      (format t \"~%ABCL: expected faileres on Travis CI: ~S, actual failures: ~S~%\"
-                              expected-failures
-                              failed-test-names)
-                      (uiop:quit 1))
-                    (format t \"ABCL failed some tests as expected on Travis CI: ~S~%\"
-                            expected-failures)))
-              #-abcl
               (unless (5am:results-status results)
                 (uiop:quit 1)))'"

--- a/cl+ssl.asd
+++ b/cl+ssl.asd
@@ -16,7 +16,8 @@
   :description "Common Lisp interface to OpenSSL."
   :license "MIT"
   :author "Eric Marsden, Jochen Schmidt, David Lichteblau"
-  :depends-on (:cffi :trivial-gray-streams :flexi-streams #+sbcl :sb-posix
+  :depends-on (:cl+ssl/config
+               :cffi :trivial-gray-streams :flexi-streams #+sbcl :sb-posix
                #+(and sbcl win32) :sb-bsd-sockets
                :bordeaux-threads :trivial-garbage :uiop
                :usocket
@@ -25,8 +26,7 @@
   :components ((:module "src"
                 :serial t
                 :components
-                ((:file "package")
-                 (:file "reload")
+                ((:file "reload")
                  (:file "conditions")
                  (:file "ffi")
                  (:file "x509")
@@ -38,3 +38,10 @@
                  (:file "random")
                  (:file "context")
                  (:file "verify-hostname")))))
+
+(defsystem :cl+ssl/config
+  :depends-on (:trivial-gray-streams :cffi)
+  :components ((:module "src"
+                :serial t
+                :components ((:file "package")
+                             (:file "config")))))

--- a/index.html
+++ b/index.html
@@ -332,6 +332,15 @@
         nor (cl+ssl:reload) try to load the foreign libraries,
         assuming user has loaded them already.</p>
 
+    <p>You will probably need to recompile CL+SSL for the feature to take
+      effect. See
+      macros <a href="#define-libssl-path"><code>define-libssl-path</code></a>
+      and <a href="#define-libcrypto-path"><code>define-libcrypto-path</code></a>
+      for a way of achieving the same thing that doesn't require
+      recompilation.</p>
+
+
+
       <pre>
         (cffi:load-foreign-library "libssl.so.1.0.0")
 
@@ -343,6 +352,50 @@
           ;; or just load cl+ssl
           (ql:quickload :cl+ssl))
       </pre>
+
+    </p>
+    <p>
+      <div class="def"><a name="define-libssl-path">
+        Macro CL+SSL:DEFINE-LIBSSL-PATH (path)
+      </a></div>
+
+      Define the path where libssl resides to be <code>path</code> (not
+      evaluated). This macro should be used before loading CL+SSL. This can be
+      accomplished by first loading the system <code>CL+SSL/CONFIG</code>, which
+      defines the macro.
+
+      For instance, the following piece of code defines libssl to be
+      <code>/opt/local/lib/libssl.dylib</code>:
+
+      <pre>
+(ql:quickload :cl+ssl/config)
+(cl+ssl:define-libssl-path "/opt/local/lib/libssl.dylib")
+(ql:quickload :cl+ssl)</pre>
+
+      See
+      also: <a href="#define-libcrypto-path"><code>define-libcrypto-path</code></a>
+
+    </p>
+    <p>
+      <div class="def"><a name="define-libcrypto-path">
+        Macro CL+SSL:DEFINE-LIBCRYPTO-PATH (path)
+      </a></div>
+
+      Define the path where libcrypto resides to be <code>path</code> (not
+      evaluated). This macro should be used before loading CL+SSL. This can be
+      accomplished by first loading the system <code>CL+SSL/CONFIG</code>, which
+      defines the macro.
+
+      For instance, the following piece of code defines libssl to be
+      <code>/opt/local/lib/libcrypto.dylib</code>:
+
+      <pre>
+(ql:quickload :cl+ssl/config)
+(cl+ssl:define-libcrypto-path "/opt/local/lib/libcrypto.dylib")
+(ql:quickload :cl+ssl)</pre>
+
+      See
+      also: <a href="#define-libssl-path"><code>define-libssl-path</code></a>
 
     </p>
     <p>

--- a/src/config.lisp
+++ b/src/config.lisp
@@ -1,0 +1,24 @@
+(in-package :cl+ssl)
+
+(defvar *libssl-override* nil)
+(defvar *libcrypto-override* nil)
+
+(defmacro define-libssl-path (path)
+  "Define the path where libssl resides to be PATH (not evaluated). This
+macroshould be used before loading CL+SSL.
+
+For instance, this defines libssl as \"/opt/local/lib/libssl.dylib\":
+
+    (ql:quickload :cl+ssl/config)
+    (cl+ssl:define-libssl-path \"/opt/local/lib/libssl.dylib\")
+    (ql:quickload :cl+ssl)"
+  `(progn
+     (cffi:define-foreign-library libssl (t ,path))
+     (setq *libssl-override* t)))
+
+(defmacro define-libcrypto-path (path)
+  "Define the path where libcrypto resides to be PATH (not evaluated). This
+macro should be used before loading CL+SSL."
+  `(progn
+     (cffi:define-foreign-library libcrypto (t ,path))
+     (setq *libcrypto-override* t)))

--- a/src/ffi.lisp
+++ b/src/ffi.lisp
@@ -111,7 +111,8 @@ variants if you have use cases for them.)"
                *cl+ssl-ssl-foreign-function-names*
                :test 'equal)
      (defcfun-versioned (:since ,since :vanished ,vanished)
-         ,(append name-and-options '(:library libssl))
+         ,(append name-and-options
+                  #-cl+ssl-foreign-libs-already-loaded '(:library libssl))
        ,@body)))
 
 (defmacro define-ssl-function (name-and-options &body body)
@@ -144,7 +145,7 @@ variants if you have use cases for them.)"
          ;; mechanism with possibility for user to specify value
          ;; for the :library option.
          ,(append name-and-options
-                  #+(and (or abcl lispworks) darwin) '(:library libcrypto))
+                  #-cl+ssl-foreign-libs-already-loaded '(:library libcrypto))
        ,@body)))
 
 (defmacro define-crypto-function (name-and-options &body body)

--- a/src/ffi.lisp
+++ b/src/ffi.lisp
@@ -125,25 +125,6 @@ variants if you have use cases for them.)"
               *cl+ssl-crypto-foreign-function-names*
               :test 'equal)
      (defcfun-versioned (:since ,since :vanished ,vanished)
-         ;; On Darwin, LispWorks has boringssl always loaded
-         ;; (https://github.com/cl-plus-ssl/cl-plus-ssl/issues/61),
-         ;; ABCL somehow has libressl loaded
-         ;; (https://github.com/cl-plus-ssl/cl-plus-ssl/pull/89),
-         ;; and when we load openssl and declare ffi functions
-         ;; without explicitly specifying the :library option,
-         ;; some foreign symbols are resolved as boringssl / libressl symbols,
-         ;; others are resolved as openssl functions.
-         ;; This mix results in failures, of course.
-         ;; We fix these two implementations by passing the :library option.
-         ;; Not for other implementations because this may be
-         ;; incompatible with :cl+ssl-foreign-libs-already-loaded
-         ;; but these two implementations just break without
-         ;; that, so it's better to possibly sacrify the
-         ;; :cl+ssl-foreign-libs-already-loaded (we haven't tested)
-         ;; than have them broken completely.
-         ;; TODO: extend the :cl+ssl-foreign-libs-already-loaded
-         ;; mechanism with possibility for user to specify value
-         ;; for the :library option.
          ,(append name-and-options
                   #-cl+ssl-foreign-libs-already-loaded '(:library libcrypto))
        ,@body)))

--- a/src/package.lisp
+++ b/src/package.lisp
@@ -13,6 +13,8 @@
 (defpackage :cl+ssl
   (:use :common-lisp :trivial-gray-streams)
   (:export #:*default-cipher-list*
+           #:define-libssl-path
+           #:define-libcrypto-path
            #:ensure-initialized
            #:reload
            #:stream-fd

--- a/src/reload.lisp
+++ b/src/reload.lisp
@@ -36,87 +36,92 @@
 ;;
 ;; These are 32-bit only.
 
-(cffi:define-foreign-library libcrypto
-  (:windows (:or #+(and windows x86-64) "libcrypto-1_1-x64.dll"
-                 #+(and windows x86) "libcrypto-1_1.dll"
-                 "libeay32.dll"))
-  (:openbsd "libcrypto.so")
-  (:darwin (:or "/opt/local/lib/libcrypto.dylib" ;; MacPorts
-                "/sw/lib/libcrypto.dylib"        ;; Fink
-                "/usr/local/opt/openssl/lib/libcrypto.dylib" ;; Homebrew
-                "/opt/homebrew/opt/openssl/lib/libcrypto.dylib" ;; Homebrew Arm64
-                "/usr/local/lib/libcrypto.dylib" ;; personalized install
+(unless *libcrypto-override*
+  (cffi:define-foreign-library libcrypto
+    (:windows (:or #+(and windows x86-64) "libcrypto-1_1-x64.dll"
+                   #+(and windows x86) "libcrypto-1_1.dll"
+                   "libeay32.dll"))
+    (:openbsd "libcrypto.so")
+    (:darwin (:or "/opt/local/lib/libcrypto.dylib"                ;; MacPorts
+                  "/sw/lib/libcrypto.dylib"                       ;; Fink
+                  "/usr/local/opt/openssl/lib/libcrypto.dylib"    ;; Homebrew
+                  "/opt/homebrew/opt/openssl/lib/libcrypto.dylib" ;; Homebrew Arm64
+                  "/usr/local/lib/libcrypto.dylib" ;; personalized install
 
-                ;; System-provided libraries. These must be loaded with an explicit
-                ;; API version, or else the process will crash (that was just a warning
-                ;; starging frmo maxOS > 10.15, and finally macOS >= 11 crashes the process
-                ;; with a fatal error)
-                ;;
-                ;; Please note that in macOS >= 11.0, these paths may not exist in the
-                ;; file system anymore, but trying to load them via dlopen will work. This
-                ;; is because macOS ships all system-provided libraries as a single
-                ;; dyld_shared_cache bundle.
-                "/usr/lib/libcrypto.44.dylib"
-                "/usr/lib/libcrypto.42.dylib"
-                "/usr/lib/libcrypto.41.dylib"
-                "/usr/lib/libcrypto.35.dylib"
+                  ;; System-provided libraries. These must be loaded with an explicit
+                  ;; API version, or else the process will crash (that was just a warning
+                  ;; starging frmo maxOS > 10.15, and finally macOS >= 11 crashes the process
+                  ;; with a fatal error)
+                  ;;
+                  ;; Please note that in macOS >= 11.0, these paths may not exist in the
+                  ;; file system anymore, but trying to load them via dlopen will work. This
+                  ;; is because macOS ships all system-provided libraries as a single
+                  ;; dyld_shared_cache bundle.
+                  "/usr/lib/libcrypto.44.dylib"
+                  "/usr/lib/libcrypto.42.dylib"
+                  "/usr/lib/libcrypto.41.dylib"
+                  "/usr/lib/libcrypto.35.dylib"
 
-                ;; The default old system libcrypto, versionless file name,
-                ;; which may have insufficient crypto and can cause
-                ;; process crash on macOS >= 11. Currently we
-                ;; are protected from the crash by the presense of
-                ;; the versioned paths above, but in fiew years,
-                ;; after those exacty versioned paths are not available,
-                ;; the crash may re-appear. So eventially we will
-                ;; need to delete the unversioned paths.
-                ;; Keeping them for a while for compatibility.
-                ;; See https://github.com/cl-plus-ssl/cl-plus-ssl/pull/115
-                "libcrypto.dylib"
-                "/usr/lib/libcrypto.dylib"))
-  (:cygwin (:or "cygcrypto-1.1.dll" "cygcrypto-1.0.0.dll")))
+                  ;; The default old system libcrypto, versionless file name,
+                  ;; which may have insufficient crypto and can cause
+                  ;; process crash on macOS >= 11. Currently we
+                  ;; are protected from the crash by the presense of
+                  ;; the versioned paths above, but in fiew years,
+                  ;; after those exacty versioned paths are not available,
+                  ;; the crash may re-appear. So eventially we will
+                  ;; need to delete the unversioned paths.
+                  ;; Keeping them for a while for compatibility.
+                  ;; See https://github.com/cl-plus-ssl/cl-plus-ssl/pull/115
+                  "libcrypto.dylib"
+                  "/usr/lib/libcrypto.dylib"))
+    ((and :unix (not :cygwin)) (:or "libcrypto.so.1.1"
+                                    "libcrypto.so.1.0.0"
+                                    "libcrypto.so"))
+    (:cygwin (:or "cygcrypto-1.1.dll" "cygcrypto-1.0.0.dll"))))
 
-(cffi:define-foreign-library libssl
-  (:windows (:or #+(and windows x86-64) "libssl-1_1-x64.dll"
-                 #+(and windows x86) "libssl-1_1.dll"
-                 "libssl32.dll"
-                 "ssleay32.dll"))
-  ;; The default OS-X libssl seems have had insufficient crypto algos
-  ;; (missing TLSv1_[1,2]_XXX methods,
-  ;; see https://github.com/cl-plus-ssl/cl-plus-ssl/issues/56)
-  ;; so first try to load possible custom installations of libssl
-  (:darwin (:or "/opt/local/lib/libssl.dylib" ;; MacPorts
-                "/sw/lib/libssl.dylib"        ;; Fink
-                "/usr/local/opt/openssl/lib/libssl.dylib" ;; Homebrew
-                "/opt/homebrew/opt/openssl/lib/libssl.dylib" ;; Homebrew Arm64
-                "/usr/local/lib/libssl.dylib" ;; personalized install
-                "libssl.dylib"                ;; default system libssl, which may have insufficient crypto
-                "/usr/lib/libssl.dylib"))
-  (:solaris (:or "/lib/64/libssl.so"
-                 "libssl.so.0.9.8" "libssl.so" "libssl.so.4"))
-  ;; Unlike some other systems, OpenBSD linker,
-  ;; when passed library name without versions at the end,
-  ;; will locate the library with highest macro.minor version,
-  ;; so we can just use just "libssl.so".
-  ;; More info at https://github.com/cl-plus-ssl/cl-plus-ssl/pull/2.
-  (:openbsd "libssl.so")
-  ((and :unix (not :cygwin)) (:or "libssl.so.1.1"
-                                  "libssl.so.1.0.2m"
-                                  "libssl.so.1.0.2k"
-                                  "libssl.so.1.0.2"
-                                  "libssl.so.1.0.1l"
-                                  "libssl.so.1.0.1j"
-                                  "libssl.so.1.0.1f"
-                                  "libssl.so.1.0.1e"
-                                  "libssl.so.1.0.1"
-                                  "libssl.so.1.0.0q"
-                                  "libssl.so.1.0.0"
-                                  "libssl.so.0.9.8ze"
-                                  "libssl.so.0.9.8"
-                                  "libssl.so.10"
-                                  "libssl.so.4"
-                                  "libssl.so"))
-  (:cygwin (:or "cygssl-1.1.dll" "cygssl-1.0.0.dll"))
-  (t (:default "libssl3")))
+(unless *libssl-override*
+  (cffi:define-foreign-library libssl
+    (:windows (:or #+(and windows x86-64) "libssl-1_1-x64.dll"
+                   #+(and windows x86) "libssl-1_1.dll"
+                   "libssl32.dll"
+                   "ssleay32.dll"))
+    ;; The default OS-X libssl seems have had insufficient crypto algos
+    ;; (missing TLSv1_[1,2]_XXX methods,
+    ;; see https://github.com/cl-plus-ssl/cl-plus-ssl/issues/56)
+    ;; so first try to load possible custom installations of libssl
+    (:darwin (:or "/opt/local/lib/libssl.dylib"                ;; MacPorts
+                  "/sw/lib/libssl.dylib"                       ;; Fink
+                  "/usr/local/opt/openssl/lib/libssl.dylib"    ;; Homebrew
+                  "/opt/homebrew/opt/openssl/lib/libssl.dylib" ;; Homebrew Arm64
+                  "/usr/local/lib/libssl.dylib" ;; personalized install
+                  "libssl.dylib" ;; default system libssl, which may have insufficient crypto
+                  "/usr/lib/libssl.dylib"))
+    (:solaris (:or "/lib/64/libssl.so"
+                   "libssl.so.0.9.8" "libssl.so" "libssl.so.4"))
+    ;; Unlike some other systems, OpenBSD linker,
+    ;; when passed library name without versions at the end,
+    ;; will locate the library with highest macro.minor version,
+    ;; so we can just use just "libssl.so".
+    ;; More info at https://github.com/cl-plus-ssl/cl-plus-ssl/pull/2.
+    (:openbsd "libssl.so")
+    ((and :unix (not :cygwin)) (:or "libssl.so.1.1"
+                                    "libssl.so.1.0.2m"
+                                    "libssl.so.1.0.2k"
+                                    "libssl.so.1.0.2"
+                                    "libssl.so.1.0.1l"
+                                    "libssl.so.1.0.1j"
+                                    "libssl.so.1.0.1f"
+                                    "libssl.so.1.0.1e"
+                                    "libssl.so.1.0.1"
+                                    "libssl.so.1.0.0q"
+                                    "libssl.so.1.0.0"
+                                    "libssl.so.0.9.8ze"
+                                    "libssl.so.0.9.8"
+                                    "libssl.so.10"
+                                    "libssl.so.4"
+                                    "libssl.so"))
+    (:cygwin (:or "cygssl-1.1.dll" "cygssl-1.0.0.dll"))
+    (t (:default "libssl3"))))
 
 (unless (member :cl+ssl-foreign-libs-already-loaded
                 *features*)


### PR DESCRIPTION
This fixes tests on ABCL, including the "expected failures" that shouldn't have been expected at all.

The problem is this: when testing, we preload "libcrypto" and "libssl", and prevent the library named by the symbol `libssl` from being loaded, but we still specify `:library libssl` in foreign function definitions.

This problem manifests on ABCL because its CFFI implementation actually uses the `:library` argument, whereas other implementations seem to simply ignore it. For instance, in cffi-sbcl you can find:
```
(defmacro %foreign-funcall (name args &key library convention)
  "Perform a foreign function call, document it more later."
  (declare (ignore library convention))
...)
```