### PR TITLE
Remove symbol undefined messages

### DIFF
--- a/src/ffi.lisp
+++ b/src/ffi.lisp
@@ -1092,8 +1092,6 @@ See ttp://www.openssl.org/support/faq.html#USER1 for details.
 
 Hint: do not use Common Lisp RANDOM function to generate the RAND-SEED,
 because the function usually returns predictable values."
-  #+lispworks
-  (check-cl+ssl-symbols)
   (bordeaux-threads:with-recursive-lock-held (*global-lock*)
     (unless (ssl-initialized-p)
       (initialize :method method :rand-seed rand-seed))


### PR DESCRIPTION

Currently on Lispworks (in particular for Darwin), I get this noise:

```
Symbol "SSL_CTX_set_default_verify_file" undefined
Symbol "SSL_CTX_set_default_verify_dir" undefined
Symbol "OpenSSL_add_all_digests" undefined
Symbol "OPENSSL_sk_num" undefined
Symbol "OPENSSL_sk_value" undefined
Symbol "SSL_CTX_set_default_verify_file" undefined
Symbol "SSL_CTX_set_default_verify_dir" undefined
Symbol "OpenSSL_add_all_digests" undefined
Symbol "OPENSSL_sk_num" undefined
Symbol "OPENSSL_sk_value" undefined
Symbol "SSL_CTX_set_default_verify_file" undefined
Symbol "SSL_CTX_set_default_verify_dir" undefined
Symbol "OpenSSL_add_all_digests" undefined
Symbol "OPENSSL_sk_num" undefined
Symbol "OPENSSL_sk_value" undefined
```

But everything works for my purposes (in particular `dexador`). I'm also sending this script to end-users, and it's difficult to get rid of it.

I don't know if this has the value it was originally supposed to have. It might better belong in a test case if it's truly supposed to catch something. I've left the function as is, just removed the reference to it.