### PR TITLE
Add support for GeneralizedTime format in X509 certifcate dates.

### DIFF
--- a/src/ffi.lisp
+++ b/src/ffi.lisp
@@ -802,6 +802,10 @@ Note: the _really_ old formats (<= 0.9.4) are not supported."
     :int
   (asn1-string :pointer))
 
+(define-crypto-function ("ASN1_UTCTIME_check" asn1-utctime-check)
+    :int
+  (asn1-string :pointer))
+
 ;; X509 & ASN1 - end
 
 (define-ssl-function ("SSL_CTX_set_default_verify_paths" ssl-ctx-set-default-verify-paths)

--- a/src/x509.lisp
+++ b/src/x509.lisp
@@ -135,23 +135,30 @@ ASN1 string validation references:
     (decode-asn1-string asn1-string type)))
 
 ;; ASN1 Times are represented with ASN1 Strings
-(defun decode-asn1-utctime (asn1-time)
+(defun decode-asn1-time (asn1-time)
   (when (zerop (asn1-time-check asn1-time))
     (error "asn1-time is not a syntactically valid ASN1 UTCTime"))
   (let ((time-string (flex:octets-to-string (asn1-string-bytes-vector asn1-time)
                                             :external-format :ascii)))
-    (flet ((get-element (position)
-             (parse-integer (subseq time-string position (+ position 2)))))
-      (let* ((year-part (get-element 0))
-             (year      (if (>= year-part 50)
-                            (+ 1900 year-part)
-                            (+ 2000 year-part)))
-             (month  (get-element 2))
-             (day    (get-element 4))
-             (hour   (get-element 6))
-             (minute (get-element 8))
-             (second (get-element 10)))
-        (encode-universal-time second minute hour day month year 0)))))
+    (let* ((utctime-p (= 1 (asn1-utctime-check asn1-time)))
+           (year-len (if utctime-p 2 4))
+           (year-part (parse-integer (subseq time-string 0 year-len)))
+           (year (if utctime-p
+                     (if (>= year-part 50)
+                         (+ 1900 year-part)
+                         (+ 2000 year-part))
+                     year-part)))
+      (flet ((get-element-after-year (position)
+               (parse-integer
+                (subseq time-string
+                        (+ position year-len)
+                        (+ position year-len 2)))))
+        (let ((month  (get-element-after-year 0))
+              (day    (get-element-after-year 2))
+              (hour   (get-element-after-year 4))
+              (minute (get-element-after-year 6))
+              (second (get-element-after-year 8)))
+          (encode-universal-time second minute hour day month year 0))))))
 
 (defun slurp-stream (stream)
   "Returns a sequence containing the STREAM bytes; the
@@ -265,7 +272,7 @@ which the certificate is not valid."
   (let ((asn1-time (x509-get0-not-after certificate)))
     (when (cffi:null-pointer-p asn1-time)
       (error "X509_get0_notAfter returned NULL"))
-    (decode-asn1-utctime asn1-time)))
+    (decode-asn1-time asn1-time)))
 
 (defun certificate-not-before-time (certificate)
   "Returns a universal-time representing the time before
@@ -278,7 +285,7 @@ which the certificate is not valid."
   (let ((asn1-time (x509-get0-not-before certificate)))
     (when (cffi:null-pointer-p asn1-time)
       (error "X509_get0_notBefore returned NULL"))
-    (decode-asn1-utctime asn1-time)))
+    (decode-asn1-time asn1-time)))
 
 (defun certificate-fingerprint (certificate &optional (algorithm :sha1))
   "Return the fingerprint of CERTIFICATE as a byte-vector. ALGORITHM is a string


### PR DESCRIPTION
A certificate's notBefore and notAfter dates can be encoded in one of two
formats: UTCTime or GeneralizedTime. Only UTCTime is currently supported. This
commit adds support for GeneralizedTime.