### PR TITLE
patch just for make it work with openssl 3.0.1 on darwin.

### DIFF
--- a/src/ffi.lisp
+++ b/src/ffi.lisp
@@ -627,7 +627,7 @@ Note: the _really_ old formats (<= 0.9.4) are not supported."
     :pointer
   (ssl ssl-pointer))
 
-(define-ssl-function-ex (:since "3.0.0") ("SSL_get1_peer_certificate" ssl-get-peer-certificate)
+(define-ssl-function-ex (:since "3.0.0") ("SSL_get1_peer_certificate" ssl-get1-peer-certificate)
     :pointer
   (ssl ssl-pointer))
 

--- a/src/ffi.lisp
+++ b/src/ffi.lisp
@@ -623,7 +623,11 @@ Note: the _really_ old formats (<= 0.9.4) are not supported."
     :long
   (ssl ssl-pointer))
 
-(define-ssl-function ("SSL_get_peer_certificate" ssl-get-peer-certificate)
+(define-ssl-function-ex (:vanished "3.0.0") ("SSL_get_peer_certificate" ssl-get-peer-certificate)
+    :pointer
+  (ssl ssl-pointer))
+
+(define-ssl-function-ex (:since "3.0.0") ("SSL_get1_peer_certificate" ssl-get-peer-certificate)
     :pointer
   (ssl ssl-pointer))
 

--- a/src/streams.lisp
+++ b/src/streams.lisp
@@ -347,7 +347,10 @@ MAKE-CONTEXT also allows to enab/disable verification."
   ;; HOSTNAME is either NIL or a string.
   (when verify-mode
     (let* ((handle (ssl-stream-handle ssl-stream))
-           (srv-cert (ssl-get-peer-certificate handle)))
+           (srv-cert (funcall (if (openssl-is-at-least 3 0 0)
+                                  'ssl-get1-peer-certificate
+                                  'ssl-get-peer-certificate)
+                              handle)))
       (unwind-protect
            (progn
              (when (and (eq :required verify-mode)


### PR DESCRIPTION
I got error 

```
The alien function "SSL_get_peer_certificate" is undefined.
   [Condition of type SB-KERNEL::UNDEFINED-ALIEN-FUNCTION-ERROR]
```

just simple patch to replace deprecated function name to new one.