### PR TITLE
.asd file improvements

### DIFF
--- a/cl+ssl.asd
+++ b/cl+ssl.asd
@@ -7,21 +7,22 @@
 ;;;
 ;;; See LICENSE for details.
 
-(defpackage :cl+ssl-system
-  (:use :cl :asdf))
-
-(in-package :cl+ssl-system)
-
 (defsystem :cl+ssl
   :description "Common Lisp interface to OpenSSL."
   :license "MIT"
   :author "Eric Marsden, Jochen Schmidt, David Lichteblau"
   :depends-on (:cl+ssl/config
-               :cffi :trivial-gray-streams :flexi-streams #+sbcl :sb-posix
-               #+(and sbcl win32) :sb-bsd-sockets
-               :bordeaux-threads :trivial-garbage :uiop
+               :cffi
+               :trivial-gray-streams
+               :flexi-streams
+               :bordeaux-threads
+               :trivial-garbage
+               :uiop
                :usocket
-               :alexandria :trivial-features)
+               :alexandria
+               :trivial-features
+               (:feature :sbcl :sb-posix)
+               (:feature (:and :sbcl :win32) :sb-bsd-sockets))
   :serial t
   :components ((:module "src"
                 :serial t
@@ -31,14 +32,16 @@
                  (:file "conditions")
                  (:file "ffi")
                  (:file "ffi-buffer-all")
-                 #-clisp (:file "ffi-buffer")
-                 #+clisp (:file "ffi-buffer-clisp")
+                 (:file "ffi-buffer" :if-feature (:not :clisp))
+                 (:file "ffi-buffer-clisp" :if-feature :clisp)
                  (:file "streams")
                  (:file "bio")
                  (:file "x509")
                  (:file "random")
                  (:file "context")
-                 (:file "verify-hostname")))))
+                 (:file "verify-hostname"))))
+  :in-order-to ((test-op (load-op :cl+ssl.test)))
+  :perform (test-op (op c) (symbol-call '#:5am '#:run! :cl+ssl)))
 
 (defsystem :cl+ssl/config
   :depends-on (:cffi)

--- a/cl+ssl.test.asd
+++ b/cl+ssl.test.asd
@@ -4,21 +4,16 @@
 ;;;
 ;;; See LICENSE for details.
 
-(defpackage :cl+ssl.test-system
-  (:use :cl :asdf))
-
-(in-package :cl+ssl.test-system)
-
-(asdf:defsystem :cl+ssl.test
+(defsystem :cl+ssl.test
   :version "0.1"
   :description "CL+SSL test suite"
   :maintainer "Ilya Khaprov <ilya.khaprov@publitechs.com>"
   :author "Ilya Khaprov <ilya.khaprov@publitechs.com>"
   :licence "MIT"
-  :depends-on (:fiveam
-               (:feature (:or :sbcl :ccl) :cl-coveralls)
-               :cl+ssl
-               :usocket)
+  :depends-on (:cl+ssl
+               :fiveam
+               :usocket
+               (:feature (:or :sbcl :ccl) :cl-coveralls))
   :serial t
   :components ((:module "test"
                 :serial t


### PR DESCRIPTION
This adds support for ASDF test-op and cleans up the .asd files a bit so they match ASDF 3 guidelines. Notably, the .asd files no longer define a separate package because it is not required anymore.