### PR TITLE
Add read-timeout support for sbcl

### DIFF
--- a/src/package.lisp
+++ b/src/package.lisp
@@ -35,6 +35,9 @@
            #:ssl-error-initialize
            #:ssl-ctx-free
 
+           #:ssl-timeout
+           #:ssl-stream-read-timeout
+
            #:with-pem-password
 
            #:+ssl-verify-none+


### PR DESCRIPTION
This isn't really meant to be accepted since it only works on sbcl so far.  It works for both BIO and non BIO way of talking to the ssl library.  I imagine I can do the same thing for CCL and some others.  I'm not sure if we can do any better than assuming that on BIO errors that if the timeout expired that the error was caused by the timeout.