### PR TITLE
ALPN (Application-Layer Protocol Negotiation) support (client-side)

### DIFF
--- a/src/ffi.lisp
+++ b/src/ffi.lisp
@@ -399,6 +399,11 @@ Note: the _really_ old formats (<= 0.9.4) are not supported."
 (define-ssl-function ("SSL_CTX_free" ssl-ctx-free)
     :void
   (ctx ssl-ctx))
+(define-ssl-function-ex (:since "1.0")  ("SSL_set_alpn_protos" ssl-set-alpn-protos)
+    :int
+  (SSL :pointer)
+  (text :string)
+  (len :int))
 (define-crypto-function ("BIO_ctrl" bio-set-fd)
     :long
   (bio :pointer)

--- a/src/ffi.lisp
+++ b/src/ffi.lisp
@@ -404,6 +404,11 @@ Note: the _really_ old formats (<= 0.9.4) are not supported."
   (SSL :pointer)
   (text :string)
   (len :int))
+(define-ssl-function-ex (:since "1.0") ("SSL_get0_alpn_selected" ssl-get0-alpn-selected)
+    :void
+  (SSL :pointer)
+  (text (:pointer :string))
+  (len (:pointer :int)))
 (define-crypto-function ("BIO_ctrl" bio-set-fd)
     :long
   (bio :pointer)

--- a/src/package.lisp
+++ b/src/package.lisp
@@ -19,6 +19,7 @@
            #:*default-buffer-size*
            #:make-ssl-client-stream
            #:*make-ssl-client-stream-verify-default*
+           #:get-selected-alpn-protocol
            #:make-ssl-server-stream
            #:*default-unwrap-stream-p*
            #:use-certificate-chain-file

--- a/src/streams.lisp
+++ b/src/streams.lisp
@@ -493,6 +493,13 @@ may be associated with the passphrase PASSWORD."
       (ensure-ssl-funcall stream handle #'ssl-accept handle)
       (handle-external-format stream external-format))))
 
+(defun get-selected-alpn-protocol (ssl)
+  "Alpn protocol agreed with the server (or nil)"
+  (cffi:with-foreign-objects ((ptr :pointer) (len :pointer))
+    (ssl-get0-alpn-selected (ssl-stream-handle ssl) ptr len)
+    (cffi:foreign-string-to-lisp (cffi:mem-ref ptr :pointer)
+                                 :count (cffi:mem-ref len :int))))
+
 #+openmcl
 (defmethod stream-deadline ((stream ccl::basic-stream))
   (ccl::ioblock-deadline (ccl::stream-ioblock stream t)))

--- a/src/streams.lisp
+++ b/src/streams.lisp
@@ -401,6 +401,14 @@ MAKE-SSL-CLIENT-STREAM - previously it worked as if :VERIFY NIL
 but then :VERIFY :REQUIRED became the default on non-Windows platforms.
 Change this variable if you want the previous behaviour.")
 
+(defun make-alpn-proto-string (protocols)
+  "Convert list of protocol names to the wire-format byte string."
+  (with-output-to-string (s)
+    (dolist (proto protocols)
+      (check-type proto string)
+      (write-char (code-char (length proto)) s)
+      (write-string proto s))))
+
 ;; fixme: free the context when errors happen in this function
 (defun make-ssl-client-stream
     (socket &key certificate key password method external-format
@@ -412,7 +420,8 @@ Change this variable if you want the previous behaviour.")
               hostname
               (buffer-size *default-buffer-size*)
               (input-buffer-size buffer-size)
-              (output-buffer-size buffer-size))
+              (output-buffer-size buffer-size)
+              alpn-protocols)
   "Returns an SSL stream for the client socket descriptor SOCKET.
 CERTIFICATE is the path to a file containing the PEM-encoded certificate for
  your client. KEY is the path to the PEM-encoded key for the client, which
@@ -427,7 +436,10 @@ HOSTNAME if specified, will be sent by client during TLS negotiation,
 according to the Server Name Indication (SNI) extension to the TLS.
 When server handles several domain names, this extension enables the server
 to choose certificate for right domain. Also the HOSTNAME is used for
-hostname verification if verification is enabled by VERIFY."
+hostname verification if verification is enabled by VERIFY.
+
+ALPN-PROTOCOLS, if specified, should be a list of alpn protocol names such as
+\"h2\" that would be offered to the server."
   (ensure-initialized :method method)
   (let ((stream (make-instance 'ssl-stream
                                :socket socket
@@ -438,6 +450,9 @@ hostname verification if verification is enabled by VERIFY."
       (if hostname
           (cffi:with-foreign-string (chostname hostname)
             (ssl-set-tlsext-host-name handle chostname)))
+      (if alpn-protocols
+          (cffi:with-foreign-string ((string len) (make-alpn-proto-string alpn-protocols))
+            (ssl-set-alpn-protos handle string (1- len))))
       (setf socket (install-handle-and-bio stream handle socket unwrap-stream-p))
       (ssl-set-connect-state handle)
       (when (zerop (ssl-set-cipher-list handle cipher-list))


### PR DESCRIPTION
This PR adds client-side support for ALPN:
- Client can specify what protocols it supports with a parameter to make-ssl-client-stream,
- Client can get what protocol, if any, was accepted by the server with new function.

Any comments/opinions on that, apart from "tests needed"? (I can try, suggestions how welcome) and "Server side support would be nice" (I am not ready for that)?

Example:
```
(usocket:with-client-socket (socket stream "www.example.com" 443)
	(cl+ssl:get-selected-alpn-protocol
              (cl+ssl:make-ssl-client-stream stream :alpn-protocols '( "h2" "http/1.1"))))
```
-> `"h2"`