### PR TITLE
Documentation (index.html) and tests for client-side alpn

### DIFF
--- a/cl+ssl.test.asd
+++ b/cl+ssl.test.asd
@@ -28,4 +28,4 @@
                  (:file "verify-hostname")
                  (:file "badssl-com")
                  (:file "bio")
-		 (:file "alpn")))))
+                 (:file "alpn")))))

--- a/cl+ssl.test.asd
+++ b/cl+ssl.test.asd
@@ -27,4 +27,5 @@
                  (:file "fingerprint")
                  (:file "verify-hostname")
                  (:file "badssl-com")
-                 (:file "bio")))))
+                 (:file "bio")
+		 (:file "alpn")))))

--- a/index.html
+++ b/index.html
@@ -313,6 +313,10 @@
       Change this variable if you want the previous behaviour.
     </p>
     <p>
+      <div class="def">Function CL+SSL:GET-SELECTED-ALPN-PROTOCOL (ssl)</div>
+      Return ALPN protocol selected by server, or NIL if none was selected. SSL is the client ssl stream returned by <tt>make-ssl-client-stream</tt>.
+    </p>
+    <p>
       <div class="def">Function CL+SSL:USE-CERTIFICATE-CHAIN-FILE (certificate-chain-file)</div>
       Loads a PEM encoded certificate chain file <tt>certificate-chain-file</tt>
       and adds the chain to global context. The certificates must be sorted 

--- a/index.html
+++ b/index.html
@@ -237,7 +237,7 @@
       If <tt>auto-free-p</tt> is true the context is freed using <tt>ssl-ctx-free</tt> before exit.
     </p>
     <p>
-      <div class="def">Function CL+SSL:MAKE-SSL-CLIENT-STREAM (fd-or-stream &amp;key external-format certificate key password close-callback (unwrap-stream-p *default-unwrap-stream-p*) verify hostname (buffer-size *default-buffer-size*) (input-buffer-size buffer-size) (output-buffer-size buffer-size))<br/><br/>
+      <div class="def">Function CL+SSL:MAKE-SSL-CLIENT-STREAM (fd-or-stream &amp;key external-format certificate key password close-callback (unwrap-stream-p *default-unwrap-stream-p*) verify hostname (buffer-size *default-buffer-size*) (input-buffer-size buffer-size) (output-buffer-size buffer-size) alpn-protocols)<br/><br/>
       Function CL+SSL:MAKE-SSL-SERVER-STREAM (fd-or-stream &amp;key external-format certificate key password close-callback (unwrap-stream-p *default-unwrap-stream-p*) (buffer-size *default-buffer-size*) (input-buffer-size buffer-size) (output-buffer-size buffer-size))</div>
       Return an SSL stream for the client (server)
       socket <tt>fd-or-stream</tt>.  All reads and writes to this
@@ -291,6 +291,11 @@
       When server handles several domain names, this extension enables the server
       to choose certificate for right domain. Also the <tt>hostname></tt> is used for
       hostname verification if verification is enabled by <tt>verify</tt>.
+    </p>
+    <p>
+      <tt>alpn-protocols</tt> if specified, should be a list of alpn protocol
+      names that would be offered to the server. Protocol selected by the server
+      can be retrieved by <tt>get-selected-alpn-protocol</tt>.
     </p>
     <p>
       <div class="def">Parameter *default-buffer-size*</div>

--- a/test/alpn.lisp
+++ b/test/alpn.lisp
@@ -8,11 +8,11 @@
 (test alpn-client
   (when (cl+ssl::openssl-is-at-least 1 0 2)
     (flet ((test-alpn-result (target proposed expected)
-	     (usocket:with-client-socket (socket stream target 443)
-	       (is
-		(equal expected
-		       (cl+ssl:get-selected-alpn-protocol
-			(cl+ssl:make-ssl-client-stream stream :alpn-protocols proposed)))))))
+             (usocket:with-client-socket (socket stream target 443)
+               (is
+                (equal expected
+                       (cl+ssl:get-selected-alpn-protocol
+                        (cl+ssl:make-ssl-client-stream stream :alpn-protocols proposed)))))))
       (test-alpn-result "example.com" nil nil)
       (test-alpn-result "example.com" '( "should-not-exist" "h2" "also-should-not-exist")
-			"h2"))))
+                        "h2"))))

--- a/test/alpn.lisp
+++ b/test/alpn.lisp
@@ -1,0 +1,18 @@
+(in-package :cl+ssl.test)
+
+(def-suite :cl+ssl.alpn :in :cl+ssl
+  :description "ALPN tests")
+
+(in-suite :cl+ssl.alpn)
+
+(test alpn-client
+  (when (cl+ssl::openssl-is-at-least 1 0 2)
+    (flet ((test-alpn-result (target proposed expected)
+	     (usocket:with-client-socket (socket stream target 443)
+	       (is
+		(equal expected
+		       (cl+ssl:get-selected-alpn-protocol
+			(cl+ssl:make-ssl-client-stream stream :alpn-protocols proposed)))))))
+      (test-alpn-result "example.com" nil nil)
+      (test-alpn-result "example.com" '( "should-not-exist" "h2" "also-should-not-exist")
+			"h2"))))


### PR DESCRIPTION
Documentation and tests for #149.

The tests were tested locally only, not across full spectrum of Lisps and SSL versions.