### PR TITLE
Improve OpenSSL 3 support

### DIFF
--- a/src/ffi.lisp
+++ b/src/ffi.lisp
@@ -728,7 +728,11 @@ Note: the _really_ old formats (<= 0.9.4) are not supported."
     :pointer
   (name :string))
 
-(define-crypto-function ("EVP_MD_size" evp-md-size)
+(define-crypto-function-ex (:vanished "3.0.0") ("EVP_MD_size" evp-md-size)
+    :int
+  (evp :pointer))
+
+(define-crypto-function-ex (:since "3.0.0") ("EVP_MD_get_size" evp-md-get-size)
     :int
   (evp :pointer))
 

--- a/src/reload.lisp
+++ b/src/reload.lisp
@@ -133,6 +133,7 @@ sudo rm /usr/local/lib/libcrypto.dylib /usr/local/lib/libssl.dylib
                   "/usr/lib/libcrypto.dylib"))
     ((and :unix (not :cygwin)) (:or "libcrypto.so.1.1"
                                     "libcrypto.so.1.0.0"
+                                    "libcrypto.so.3"
                                     "libcrypto.so"))
     (:cygwin (:or "cygcrypto-1.1.dll" "cygcrypto-1.0.0.dll"))))
 
@@ -183,6 +184,7 @@ sudo rm /usr/local/lib/libcrypto.dylib /usr/local/lib/libssl.dylib
                                     "libssl.so.0.9.8"
                                     "libssl.so.10"
                                     "libssl.so.4"
+                                    "libssl.so.3"
                                     "libssl.so"))
     (:cygwin (:or "cygssl-1.1.dll" "cygssl-1.0.0.dll"))
     (t (:default "libssl3"))))

--- a/src/x509.lisp
+++ b/src/x509.lisp
@@ -296,7 +296,10 @@ designator for the digest algorithm to use (it defaults to SHA-1)."
       (error 'ssl-error-call
              :message (format nil "unknown digest algorithm ~A" algorithm)
              :queue (read-ssl-error-queue)))
-    (let* ((size (evp-md-size evp))
+    (let* ((size (funcall (if (openssl-is-at-least 3 0 0)
+                                  'evp-md-get-size
+                                  'evp-md-size)
+                          evp))
            (fingerprint (cffi:make-shareable-byte-vector size)))
       (cffi:with-pointer-to-vector-data (buf fingerprint)
         (unless (= 1 (x509-digest certificate evp buf (cffi:null-pointer)))


### PR DESCRIPTION
* allow OpenSSL 3 for unix in reload.lisp
* Use new EVP_MD_get_size, when available