### PR TITLE
Add READ-TIMEOUT and WRITE-TIMEOUT support

### DIFF
--- a/src/streams.lisp
+++ b/src/streams.lisp
@@ -460,9 +460,12 @@ to choose certificate for right domain. Also the HOSTNAME is used for
 hostname verification if verification is enabled by VERIFY.
 
 READ-TIMEOUT and WRITE-TIMEOUT specify a timeout in seconds before
-which to signal an SSL-TIMEOUT error.  After the timeout we throw an
-SSL-TIMEOUT error.  On CCL or MCL, though, we also honor the
-underlying stream timeout and throw a CCL specific error.
+which to signal an SSL-TIMEOUT error.  On CCL or MCL, for backwards
+compatibility, we also honor the underlying stream timeout if it is a
+ccl::basic-stream and throw a CCL specific error.  These timeouts are
+only applicable if unwrap-stream-p is true.  In the unwrap-stream-p
+case, though, any implementation dependent stream timeout features are
+applicable (for example usocket timeouts, etc).
 
 ALPN-PROTOCOLS, if specified, should be a list of alpn protocol names such as
 \"h2\" that would be offered to the server."
@@ -508,9 +511,12 @@ CERTIFICATE is the path to a file containing the PEM-encoded certificate for
 may be associated with the passphrase PASSWORD.
 
 READ-TIMEOUT and WRITE-TIMEOUT specify a timeout in seconds before
-which to signal an SSL-TIMEOUT error.  On CCL and MCL we honor the
-underlying socket timeout settings and throw an implementation specific
-error for backwards compatibility reasons."
+which to signal an SSL-TIMEOUT error.  On CCL or MCL, for backwards
+compatibility, we also honor the underlying stream timeout if it is a
+ccl::basic-stream and throw a CCL specific error.  These timeouts are
+only applicable if unwrap-stream-p is true.  In the unwrap-stream-p
+case, though, any implementation dependent stream timeout features are
+applicable (for example usocket timeouts, etc)."
   (ensure-initialized :method method)
   (let ((stream (make-instance 'ssl-server-stream
                                :socket socket


### PR DESCRIPTION
Throws an SSL-TIMEOUT error on timeout.

The behavior applies to both full operations (read-sequence) or individual operations making up the calls.

Continue to support MCL/CCL underlying stream deadlines which when triggered throws an internal CCL error.

Continue to support slot ssl-stream-deadline in case people were using it (despite it not being exported).

I believe this addresses your worries about deadlines and timeouts --- I use a 'nestable' with-timeout macro that is used in ensure-ssl-funcall as well as in stream-read-sequence and stream-write-sequence.  This means the timeout applies to the whole of the read-sequence operation.  In future changes, forgetting to add the with-timeout wrapper means that the timeout applies to underlying individual io calls.  This is implemented as you suggested by having ssl-stream-operation-started always be :not-in-progress until a with-timeout macro is hit, and then it is set to something.  Once it is set, further recursive calls do not update it. There should be no way to get a spurious deadline where there shouldn't be one as it is cleared in an unwind-protect when leaving the outer-most with-timeout call.

The only thing I find aesthetically wrong about the solution is that the macro is used both in ffi.lisp and streams.lisp and lives in ffi.lisp but knows stuff about streams.  If you have any suggestions, I can do make them.

I tested this on SBCL and dexador and it works fine.  I did not test on any other implementation... I don't have any setup, and as you can guess I have very limited time for these endeavors.  I would appreciate any help.