### PR TITLE
Fix issue of having both x86-64 and arm64 Homebrew installation and running lisp with arm64 architecture

### DIFF
--- a/src/reload.lisp
+++ b/src/reload.lisp
@@ -102,8 +102,8 @@ sudo rm /usr/local/lib/libcrypto.dylib /usr/local/lib/libssl.dylib
 
     ((:and :darwin :cl+ssl-macports-found) "/opt/local/lib/libcrypto.dylib")
     ((:and :darwin :cl+ssl-fink-found) "/sw/lib/libcrypto.dylib")
-    ((:and :darwin :cl+ssl-homebrew-found) "/usr/local/opt/openssl/lib/libcrypto.dylib")
-    ((:and :darwin :cl+ssl-homebrew-arm64-found) "/opt/homebrew/opt/openssl/lib/libcrypto.dylib")
+    ((:and :darwin :x86-64 :cl+ssl-homebrew-found) "/usr/local/opt/openssl/lib/libcrypto.dylib")
+    ((:and :darwin :arm64 :cl+ssl-homebrew-arm64-found) "/opt/homebrew/opt/openssl/lib/libcrypto.dylib")
     ((:and :darwin :cl+ssl-personalized-install-found) "/usr/local/lib/libcrypto.dylib")
     (:darwin (:or ;; System-provided libraries. Must be loaded from files with
                   ;; names that include version explicitly, instead of any
@@ -149,8 +149,8 @@ sudo rm /usr/local/lib/libcrypto.dylib /usr/local/lib/libssl.dylib
 
     ((:and :darwin :cl+ssl-macports-found) "/opt/local/lib/libssl.dylib")
     ((:and :darwin :cl+ssl-fink-found) "/sw/lib/libssl.dylib")
-    ((:and :darwin :cl+ssl-homebrew-found) "/usr/local/opt/openssl/lib/libssl.dylib")
-    ((:and :darwin :cl+ssl-homebrew-arm64-found) "/opt/homebrew/opt/openssl/lib/libssl.dylib")
+    ((:and :darwin :x86-64 :cl+ssl-homebrew-found) "/usr/local/opt/openssl/lib/libssl.dylib")
+    ((:and :darwin :arm64 :cl+ssl-homebrew-arm64-found) "/opt/homebrew/opt/openssl/lib/libssl.dylib")
     ((:and :darwin :cl+ssl-personalized-install-found) "/usr/local/lib/libssl.dylib")
     (:darwin (:or ;; System-provided libraries, with version in the file name.
                   ;; See the comment for the libcryto equivalents above.


### PR DESCRIPTION
When you are having both x86-64 and ARM Homebrew, and running LISP with arm architecture, attempt to load cl+ssl fails with error:

```
Unable to load foreign library (LIBCRYPTO).
  Error opening shared object "/usr/local/Cellar/openssl@1.1/1.1.1s/lib/libcrypto.1.1.dylib":
  dlopen(/usr/local/Cellar/openssl@1.1/1.1.1s/lib/libcrypto.1.1.dylib, 10): no suitable image found.  Did find:
        /usr/local/Cellar/openssl@1.1/1.1.1s/lib/libcrypto.1.1.dylib: mach-o, but wrong architecture
        /usr/local/Cellar/openssl@1.1/1.1.1s/lib/libcrypto.1.1.dylib: stat() failed with errno=4.
   [Condition of type CFFI:LOAD-FOREIGN-LIBRARY-ERROR]
```

This is because [this code](https://github.com/cl-plus-ssl/cl-plus-ssl/blob/13d824e27cf7f6085086458daea1514b605b3980/src/reload.lisp#L105-L106) tries to load x86 version of the library first and fails.

My patch fixes this by removing one or another path depending on current Lisp architecture.