### PR TITLE
Fix memory corruption and leaks on clisp

### DIFF
--- a/src/ffi-buffer-all.lisp
+++ b/src/ffi-buffer-all.lisp
@@ -11,6 +11,4 @@
   make-buffer
   buffer-length
   buffer-elt
-  set-buffer-elt
-  s/b-replace
-  b/s-replace))
+  set-buffer-elt))

--- a/src/ffi-buffer-clisp.lisp
+++ b/src/ffi-buffer-clisp.lisp
@@ -132,22 +132,21 @@ Improvements: In this updated version of the file:
   (let ((ptr (clisp-ffi-buffer-pointer buf))
         (c-type (make-array 3 :initial-contents #(ffi:c-array ffi:uint8 0)))
         (n (min (- end1 start1) (- end2 start2))))
-    (labels ((replace-buf-mem (s1 count vec s2)
+    (labels ((set-buf-mem (s1 count vec s2)
                "replaces exactly COUNT elts of BUF starting at S1 with elts of
                 VEC starting at S2"
                (declare (type vector vec))
                (setf (svref c-type 2) count)
                (setf (ffi:memory-as ptr c-type s1)
                      (cond ((and (zerop s2) (= count (length vec))) vec)
-                           (t
-                            (make-array count
-                                        :element-type (array-element-type vec)
-                                        :displaced-to vec
-                                        :displaced-index-offset s2))))))
+                           (t (make-array count
+                                          :element-type (array-element-type vec)
+                                          :displaced-to vec
+                                          :displaced-index-offset s2))))))
       (etypecase seq
         (vector
          (assert (<= end2 (length seq)))
-         (replace-buf-mem start1 n seq start2))
+         (set-buf-mem start1 n seq start2))
         (list
          (do* ((tmp (make-array (min n +mem-max+)
                                 :element-type '(unsigned-byte 8)))
@@ -160,7 +159,7 @@ Improvements: In this updated version of the file:
              (assert seq2)
              (setf (aref tmp i) (car seq2)
                    seq2 (cdr seq2)))
-           (replace-buf-mem s1 m tmp 0))))))
+           (set-buf-mem s1 m tmp 0))))))
   buf)
 
 (defmacro with-pointer-to-vector-data ((ptr buf) &body body)

--- a/src/ffi-buffer-clisp.lisp
+++ b/src/ffi-buffer-clisp.lisp
@@ -89,7 +89,7 @@ Improvements: In this updated version of the file:
   (setf (ffi:memory-as (clisp-ffi-buffer-pointer buf) 'ffi:uint8 index) val))
 (defsetf buffer-elt set-buffer-elt)
 
-(defparameter *mem-max* 1024 "so *-REPLACE require the expected O(1) memory")
+(defconstant +mem-max+ 1024 "so *-REPLACE require the expected O(1) memory")
 
 (defun s/b-replace (seq buf &key (start1 0) end1 (start2 0) end2)
   (when (null end1) (setf end1 (length seq)))
@@ -98,7 +98,7 @@ Improvements: In this updated version of the file:
     (do* ((remainder n (- remainder m))
           (s1 start1 (+ s1 m))
           (s2 start2 (+ s2 m))
-          (m (min remainder *mem-max*) (min remainder *mem-max*)))
+          (m (min remainder +mem-max+) (min remainder +mem-max+)))
          ((zerop m) seq)
       (replace
         seq
@@ -126,12 +126,12 @@ Improvements: In this updated version of the file:
       (cond ((typep seq 'vector) (replace-buf start1 n seq start2))
             (t
              (assert (consp seq))
-             (let ((vec2 (make-array (min n *mem-max*)
-                                    :element-type '(unsigned-byte 8)))
+             (let ((vec2 (make-array (min n +mem-max+)
+                                     :element-type '(unsigned-byte 8)))
                    (seq2 (nthcdr start2 seq)))
                (do* ((remainder n (- remainder m))
                      (s1 start1 (+ s1 m))
-                     (m (min remainder *mem-max*) (min remainder *mem-max*)))
+                     (m (min remainder +mem-max+) (min remainder +mem-max+)))
                     ((zerop m))
                  (dotimes (i m)
                    (setf (aref vec2 i) (car seq2)

--- a/src/ffi-buffer-clisp.lisp
+++ b/src/ffi-buffer-clisp.lisp
@@ -94,49 +94,73 @@ Improvements: In this updated version of the file:
 (defun s/b-replace (seq buf &key (start1 0) end1 (start2 0) end2)
   (when (null end1) (setf end1 (length seq)))
   (when (null end2) (setf end2 (buffer-length buf)))
-  (let ((n (min (- end1 start1) (- end2 start2))))
-    (do* ((remainder n (- remainder m))
-          (s1 start1 (+ s1 m))
-          (s2 start2 (+ s2 m))
-          (m (min remainder +mem-max+) (min remainder +mem-max+)))
-         ((zerop m) seq)
-      (replace
-        seq
-        (ffi:memory-as (clisp-ffi-buffer-pointer buf)
-                       (ffi:parse-c-type `(ffi:c-array ffi:uint8 ,m))
-                       s2)
-        :start1 s1))))
+  (assert (<= 0 start1 end1)) ;length expensive. code deals correctly.
+  (assert (<= 0 start2 end2 (buffer-length buf)))
+  (let ((ptr (clisp-ffi-buffer-pointer buf))
+        (c-type (make-array 3 :initial-contents #(ffi:c-array ffi:uint8 0)))
+        (n (min (- end1 start1) (- end2 start2))))
+    (labels ((buf-mem (s2 count)
+               "returns exactly COUNT elts of BUF starting at S2"
+               (setf (svref c-type 2) count)
+               (ffi:memory-as ptr c-type s2)))
+      (etypecase seq
+        (vector
+         (do* ((remainder n (- remainder m))
+               (s1 start1 e1)
+               (s2 start2 (+ s2 m))
+               (m (min remainder +mem-max+) (min remainder +mem-max+))
+               (e1 (+ s1 m) (+ s1 m)))
+              ((zerop m))
+           (replace seq (buf-mem s2 m) :start1 s1 :end1 e1)))
+        (list
+         (do* ((remainder n (- remainder m))
+               (s2 start2 (+ s2 m))
+               (seq1 (nthcdr start1 seq))
+               (m (min remainder +mem-max+) (min remainder +mem-max+)))
+              ((zerop m))
+           (let ((tmp (buf-mem s2 m)))
+             (dotimes (i m)
+               (setf (car seq1) (aref tmp i)
+                     seq1 (cdr seq1)))))))))
+  seq)
 
 (defun b/s-replace (buf seq &key (start1 0) end1 (start2 0) end2)
-  (labels ((replace-buf (s1 count vec s2)
-             "replaces exactly COUNT elts of BUF starting at S1 with elts of
-              VEC starting at S2"
-             (declare (type vector vec))
-             (setf
-               (ffi:memory-as (clisp-ffi-buffer-pointer buf)
-                              (ffi:parse-c-type `(ffi:c-array ffi:uint8 ,count))
-                              s1)
-               (cond ((= count (length vec)) (assert (zerop s2)) vec)
-                     (t (make-array count :element-type (array-element-type vec)
-                                          :displaced-to vec
-                                          :displaced-index-offset s2))))))
-    (when (null end1) (setf end1 (buffer-length buf)))
-    (when (null end2) (setf end2 (length seq)))
-    (let ((n (min (- end1 start1) (- end2 start2))))
-      (cond ((typep seq 'vector) (replace-buf start1 n seq start2))
-            (t
-             (assert (consp seq))
-             (let ((vec2 (make-array (min n +mem-max+)
-                                     :element-type '(unsigned-byte 8)))
-                   (seq2 (nthcdr start2 seq)))
-               (do* ((remainder n (- remainder m))
-                     (s1 start1 (+ s1 m))
-                     (m (min remainder +mem-max+) (min remainder +mem-max+)))
-                    ((zerop m))
-                 (dotimes (i m)
-                   (setf (aref vec2 i) (car seq2)
-                         seq2 (cdr seq2)))
-                 (replace-buf s1 m vec2 0)))))))
+  (when (null end1) (setf end1 (buffer-length buf)))
+  (when (null end2) (setf end2 (length seq)))
+  (assert (<= 0 start1 end1 (buffer-length buf)))
+  (assert (<= 0 start2 end2)) ;length expensive. code deals correctly.
+  (let ((ptr (clisp-ffi-buffer-pointer buf))
+        (c-type (make-array 3 :initial-contents #(ffi:c-array ffi:uint8 0)))
+        (n (min (- end1 start1) (- end2 start2))))
+    (labels ((replace-buf-mem (s1 count vec s2)
+               "replaces exactly COUNT elts of BUF starting at S1 with elts of
+                VEC starting at S2"
+               (declare (type vector vec))
+               (setf (svref c-type 2) count)
+               (setf (ffi:memory-as ptr c-type s1)
+                     (cond ((and (zerop s2) (= count (length vec))) vec)
+                           (t
+                            (make-array count
+                                        :element-type (array-element-type vec)
+                                        :displaced-to vec
+                                        :displaced-index-offset s2))))))
+      (etypecase seq
+        (vector
+         (assert (<= end2 (length seq)))
+         (replace-buf-mem start1 n seq start2))
+        (list
+         (do* ((tmp (make-array (min n +mem-max+)
+                                :element-type '(unsigned-byte 8)))
+               (remainder n (- remainder m))
+               (s1 start1 (+ s1 m))
+               (seq2 (nthcdr start2 seq))
+               (m (min remainder +mem-max+) (min remainder +mem-max+)))
+              ((zerop m))
+           (dotimes (i m)
+             (assert seq2)
+             (setf (aref tmp i) (car seq2)
+                   seq2 (cdr seq2)))
+           (replace-buf-mem s1 m tmp 0))))))
   buf)
 
 (defmacro with-pointer-to-vector-data ((ptr buf) &body body)

--- a/src/ffi-buffer.lisp
+++ b/src/ffi-buffer.lisp
@@ -6,6 +6,8 @@
 
 (in-package :cl+ssl)
 
+(declaim (inline s/b-replace b/s-replace))
+
 (defun make-buffer (size)
   (cffi:make-shareable-byte-vector size))
 

--- a/src/ffi-buffer.lisp
+++ b/src/ffi-buffer.lisp
@@ -6,7 +6,7 @@
 
 (in-package :cl+ssl)
 
-(declaim (inline s/b-replace b/s-replace))
+(declaim (inline s/b-replace b/s-replace release-buffer))
 
 (defun make-buffer (size)
   (cffi:make-shareable-byte-vector size))

--- a/src/ffi-buffer.lisp
+++ b/src/ffi-buffer.lisp
@@ -9,6 +9,9 @@
 (defun make-buffer (size)
   (cffi:make-shareable-byte-vector size))
 
+(defun release-buffer (buf)
+  (declare (ignore buf)))
+
 (defun buffer-length (buf)
   (length buf))
 

--- a/src/random.lisp
+++ b/src/random.lisp
@@ -12,14 +12,16 @@ the bytes as a SIMPLE-ARRAY with ELEMENT-TYPE '(UNSIGNED-BYTE 8). Signals
 an ERROR in case of problems; for example, when the OpenSSL random number
 generator has not been seeded with enough randomness to ensure an
 unpredictable byte sequence."
-  (let* ((result (make-array count :element-type '(unsigned-byte 8)))
-         (buf (make-buffer count))
-         (ret (with-pointer-to-vector-data (ptr buf)
-                (rand-bytes ptr count))))
-    (when (/= 1 ret)
-      (error "RANDOM-BYTES failed: error reported by the OpenSSL RAND_bytes function. ~A."
-             (format-ssl-error-queue nil (read-ssl-error-queue))))
-    (s/b-replace result buf)))
+  (let ((result (make-array count :element-type '(unsigned-byte 8)))
+        (buf (make-buffer count)))
+    (unwind-protect
+      (let ((ret (with-pointer-to-vector-data (ptr buf)
+                   (rand-bytes ptr count))))
+        (when (/= 1 ret)
+          (error "RANDOM-BYTES failed: error reported by the OpenSSL RAND_bytes function. ~A."
+                 (format-ssl-error-queue nil (read-ssl-error-queue))))
+        (s/b-replace result buf))
+      (release-buffer buf))))
 
 ;; TODO: Should we define random-specific constants and condition classes for
 ;; RAND_F_RAND_GET_RAND_METHOD, RAND_F_SSLEAY_RAND_BYTES, RAND_R_PRNG_NOT_SEEDED

--- a/src/streams.lisp
+++ b/src/streams.lisp
@@ -79,7 +79,7 @@
   (cond
     ((ssl-stream-handle stream)
      (unless abort
-       (force-output stream)
+       (stream-force-output stream)
        (ensure-ssl-funcall stream
                            (complement #'minusp)
                            #'ssl-shutdown
@@ -152,7 +152,7 @@
 (defmethod stream-write-byte ((stream ssl-stream) b)
   (let ((buf (ssl-stream-output-buffer stream)))
     (when (eql (buffer-length buf) (ssl-stream-output-pointer stream))
-      (force-output stream))
+      (stream-force-output stream))
     (setf (buffer-elt buf (ssl-stream-output-pointer stream)) b)
     (incf (ssl-stream-output-pointer stream)))
   b)
@@ -162,7 +162,7 @@
          (len (buffer-length buf)))
     (do () ((>= start end) seq)
       (when (= (ssl-stream-output-pointer stream) len)
-        (force-output stream))
+        (stream-force-output stream))
       (b/s-replace buf seq :start1 (ssl-stream-output-pointer stream) :end1 len
                            :start2 start :end2 end)
       (let ((n (min (- end start) (- len (ssl-stream-output-pointer stream)))))

--- a/src/x509.lisp
+++ b/src/x509.lisp
@@ -164,25 +164,16 @@ ASN1 string validation references:
               (second (get-element-after-year 8)))
           (encode-universal-time second minute hour day month year 0))))))
 
-(defun slurp-stream (stream)
-  "Returns a sequence containing the STREAM bytes; the
-sequence is created by CFFI:MAKE-SHAREABLE-BYTE-VECTOR,
-therefore it can safely be passed to
- CFFI:WITH-POINTER-TO-VECTOR-DATA."
-  (let ((seq (cffi:make-shareable-byte-vector (file-length stream))))
-    (read-sequence seq stream)
-    seq))
-
-(defgeneric decode-certificate (format bytes)
+(defgeneric decode-certificate (format buffer)
   (:documentation
-   "The BYTES must be created by CFFI:MAKE-SHAREABLE-BYTE-VECTOR (because
-we are going to pass them to CFFI:WITH-POINTER-TO-VECTOR-DATA)"))
+   "The BUFFER must be created by MAKE-BUFFER (because
+we are going to pass it to WITH-POINTER-TO-VECTOR-DATA)"))
 
-(defmethod decode-certificate ((format (eql :der)) bytes)
-  (cffi:with-pointer-to-vector-data (buf* bytes)
+(defmethod decode-certificate ((format (eql :der)) buffer)
+  (with-pointer-to-vector-data (buf* buffer)
     (cffi:with-foreign-object (buf** :pointer)
       (setf (cffi:mem-ref buf** :pointer) buf*)
-      (let ((cert (d2i-x509 (cffi:null-pointer) buf** (length bytes))))
+      (let ((cert (d2i-x509 (cffi:null-pointer) buf** (buffer-length buffer))))
         (when (cffi:null-pointer-p cert)
           (error 'ssl-error-call :message "d2i-X509 failed" :queue (read-ssl-error-queue)))
         cert))))
@@ -194,10 +185,17 @@ we are going to pass them to CFFI:WITH-POINTER-TO-VECTOR-DATA)"))
       :pem))
 
 (defun decode-certificate-from-file (path &key format)
-  (let ((bytes (with-open-file (stream path :element-type '(unsigned-byte 8))
-                 (slurp-stream stream)))
-        (format (or format (cert-format-from-path path))))
-    (decode-certificate format bytes)))
+  (unless format
+    (setf format (cert-format-from-path path)))
+  (with-open-file (stream path :element-type '(unsigned-byte 8))
+    (let* ((file-len (file-length stream))
+           (tmp (make-array file-len :element-type '(unsigned-byte 8)))
+           (buf (make-buffer file-len)))
+      (unwind-protect
+        (progn
+          (assert (= (read-sequence tmp stream) file-len))
+          (decode-certificate format (b/s-replace buf tmp)))
+        (release-buffer buf)))))
 
 (defun certificate-alt-names (cert)
   #|


### PR DESCRIPTION
----
Files
  ffi-buffer.lisp
  ffi-buffer-clisp.lisp
  streams.lisp
  random.lisp
  x509.lisp

----
Memory corruption bug on clisp

s/b-replace
b/s-replace
had bugs that could cause them to miscalculate the buffer's end as being
beyond its boundary, or miscalculate the number of bytes to copy if the
buffer's end was specified but the sequence was smaller.
All callers of s/b-replace happened to pass arguments that didn't trigger
its bugs.
But one caller of b/s-replace (namely stream-write-sequence) could
legitimately call it in a way that did trigger one of its bugs.
E.g. if the buffer was smaller than the sequence, it would corrupt memory
by writing beyond the buffer's bounds.

I have fixed all the bugs, which were in s/b-replace and b/s-replace.

----
Performance

For clisp:

b/s-replace also copies less.
The old version always called subseq, which copies.
The new version copies only if the source seq is not a vector.

s/b-replace is not expected to allocate memory proportional to its
input arrays.
But due to its call to memory-as, it did.
Now it doesn't. It allocates O(1) memory, regardless of input array sizes.

b/s-replace also allocates O(1) memory now.

For all lisps:

stream-read-sequence
I have made this clearer.

stream-write-sequence
I have rewritten this to be clearer.
And faster. The old version could flush a non-full stream.
As a pathological case,
  writing 1 byte, then 2048 times writing 2049 bytes, would cause 4096
  flushes.
Now that will cause only 2049 flushes.

----
Memory leak on clisp

There was also a memory leak because foreign buffers were allocated but
never freed. I have fixed this by extending the buffer API and having
all callers of make-buffer also release the buffer when finished with it.