### PR TITLE
Make loadable on clisp without threads

### DIFF
--- a/cl+ssl.asd
+++ b/cl+ssl.asd
@@ -15,8 +15,8 @@
                :cffi
                :trivial-gray-streams
                :flexi-streams
-               :bordeaux-threads
-               :trivial-garbage
+               (:feature (:or (:not :clisp) :mt) :bordeaux-threads)
+               (:feature (:or (:not :clisp) :mt) :trivial-garbage)
                :uiop
                :usocket
                :alexandria
@@ -33,6 +33,8 @@
                  (:file "bio")
                  (:file "conditions")
                  (:file "ssl-funcall")
+                 (:file "threads-impossible"  :if-feature (:and :clisp (:not :mt)))
+                 (:file "threads-conceivable" :if-feature (:or (:not :clisp) :mt))
                  (:file "init")
                  (:file "ffi-buffer-all")
                  (:file "ffi-buffer" :if-feature (:not :clisp))

--- a/src/init.lisp
+++ b/src/init.lisp
@@ -84,44 +84,6 @@ will use this value.")
     (cffi:with-pointer-to-vector-data (ptr buf)
       (rand-seed ptr length))))
 
-(defvar *locks*)
-
-;; zzz as of early 2011, bxthreads is totally broken on SBCL wrt. explicit
-;; locking of recursive locks.  with-recursive-lock works, but acquire/release
-;; don't.  Hence we use non-recursize locks here (but can use a recursive
-;; lock for the global lock).
-
-(cffi:defcallback locking-callback :void
-    ((mode :int)
-     (n :int)
-     (file :pointer) ;; could be (file :string), but we don't use FILE, so avoid the conversion
-     (line :int))
-  (declare (ignore file line))
-  ;; (assert (logtest mode (logior +CRYPTO-READ+ +CRYPTO-WRITE+)))
-  (let ((lock (elt *locks* n)))
-    (cond
-      ((logtest mode +CRYPTO-LOCK+)
-       (bt:acquire-lock lock))
-      ((logtest mode +CRYPTO-UNLOCK+)
-       (bt:release-lock lock))
-      (t
-       (error "fell through")))))
-
-(defvar *threads* (trivial-garbage:make-weak-hash-table :weakness :key))
-(defvar *thread-counter* 0)
-
-(defparameter *global-lock*
-  (bordeaux-threads:make-recursive-lock "SSL initialization"))
-
-;; zzz BUG: On a 32-bit system and under non-trivial load, this counter
-;; is likely to wrap in less than a year.
-(cffi:defcallback threadid-callback :unsigned-long ()
-  (bordeaux-threads:with-recursive-lock-held (*global-lock*)
-    (let ((self (bt:current-thread)))
-      (or (gethash self *threads*)
-          (setf (gethash self *threads*)
-                (incf *thread-counter*))))))
-
 (defvar *ssl-check-verify-p* :unspecified
   "DEPRECATED.
 Use the (MAKE-SSL-CLIENT-STREAM .. :VERIFY ?) to enable/disable verification.
@@ -140,11 +102,7 @@ MAKE-CONTEXT also allows to enab/disable verification.")
             ;; new versions keep this API backwards
             ;; compatible so we can call it too.
             (libresslp))
-    (setf *locks* (loop
-                     repeat (crypto-num-locks)
-                     collect (bt:make-lock)))
-    (crypto-set-locking-callback (cffi:callback locking-callback))
-    (crypto-set-id-callback (cffi:callback threadid-callback))
+    (threading-initialize)
     (ssl-load-error-strings)
     (ssl-library-init)
     ;; However, for OpenSSL_add_all_digests the LibreSSL breaks
@@ -199,7 +157,7 @@ Keyword arguments:
 "
   #+lispworks
   (check-cl+ssl-symbols)
-  (bordeaux-threads:with-recursive-lock-held (*global-lock*)
+  (threading-with-global-lock-held
     (unless (ssl-initialized-p)
       (initialize :method method :rand-seed rand-seed))))
 

--- a/src/init.lisp
+++ b/src/init.lisp
@@ -192,7 +192,7 @@ https://github.com/cl-plus-ssl/cl-plus-ssl/issues/167
   (detect-custom-openssl-installations-if-macos)
   (unless (member :cl+ssl-foreign-libs-already-loaded
                   *features*)
-    (cffi:use-foreign-library libcrypto)
+    (cffi:load-foreign-library 'libcrypto)
     (cffi:load-foreign-library 'libssl))
   (setf *ssl-global-context* nil)
   (setf *ssl-global-method* nil)

--- a/src/threads-conceivable.lisp
+++ b/src/threads-conceivable.lisp
@@ -1,3 +1,9 @@
+;;;; -*- Mode: LISP; Syntax: COMMON-LISP; indent-tabs-mode: nil; coding: utf-8; show-trailing-whitespace: t -*-
+;;;
+;;; Copyright (C) contributors as per cl+ssl git history
+;;;
+;;; See LICENSE for details.
+
 (eval-when (:compile-toplevel)
   (declaim
    (optimize (speed 3) (space 1) (safety 1) (debug 0) (compilation-speed 0))))

--- a/src/threads-conceivable.lisp
+++ b/src/threads-conceivable.lisp
@@ -1,0 +1,54 @@
+(eval-when (:compile-toplevel)
+  (declaim
+   (optimize (speed 3) (space 1) (safety 1) (debug 0) (compilation-speed 0))))
+
+(in-package :cl+ssl)
+
+(defvar *locks*)
+
+;; zzz as of early 2011, bxthreads is totally broken on SBCL wrt. explicit
+;; locking of recursive locks.  with-recursive-lock works, but acquire/release
+;; don't.  Hence we use non-recursize locks here (but can use a recursive
+;; lock for the global lock).
+
+(cffi:defcallback locking-callback :void
+    ((mode :int)
+     (n :int)
+     (file :pointer) ;; could be (file :string), but we don't use FILE, so avoid the conversion
+     (line :int))
+  (declare (ignore file line))
+  ;; (assert (logtest mode (logior +CRYPTO-READ+ +CRYPTO-WRITE+)))
+  (let ((lock (svref *locks* n)))
+    (cond
+      ((logtest mode +CRYPTO-LOCK+)
+       (bt:acquire-lock lock))
+      ((logtest mode +CRYPTO-UNLOCK+)
+       (bt:release-lock lock))
+      (t
+       (error "fell through")))))
+
+(defvar *threads* (trivial-garbage:make-weak-hash-table :weakness :key))
+(defvar *thread-counter* 0)
+
+(defparameter *global-lock*
+  (bt:make-recursive-lock "SSL initialization"))
+
+;; zzz BUG: On a 32-bit system and under non-trivial load, this counter
+;; is likely to wrap in less than a year.
+(cffi:defcallback threadid-callback :unsigned-long ()
+  (bt:with-recursive-lock-held (*global-lock*)
+    (let ((self (bt:current-thread)))
+      (or (gethash self *threads*)
+          (setf (gethash self *threads*)
+                (incf *thread-counter*))))))
+
+(defun threading-initialize ()
+    (setf *locks* (let ((result (make-array (crypto-num-locks))))
+                    (dotimes (i (length result) result)
+                      (setf (svref result i) (bt:make-lock)))))
+    (crypto-set-locking-callback (cffi:callback locking-callback))
+    (crypto-set-id-callback (cffi:callback threadid-callback)))
+
+(defmacro threading-with-global-lock-held (&body body)
+  `(bt:with-recursive-lock-held (*global-lock*)
+     ,@body))

--- a/src/threads-impossible.lisp
+++ b/src/threads-impossible.lisp
@@ -1,0 +1,11 @@
+;;;; This should only be loaded/used if there is no way for the user
+;;;; to get his/her Lisp process to create a second thread. If there is
+;;;; any conceivable way for a second thread to be created in the Lisp
+;;;; implementation, then this file should not be loaded.
+
+(in-package :cl+ssl)
+
+(defun threading-initialize ())
+
+(defmacro threading-with-global-lock-held (&body body)
+  (cons 'progn body))


### PR DESCRIPTION
Bordeaux-threads used to be a portability layer over threaded and non-threaded Lisps such that libraries (such as cl+ssl) could write (make-lock) and (acquire-lock) without read conditionals to check whether the Lisp implementation supported threads at all. Bordeaux-threads provided correct no-op definitions for such functions on non-threaded Lisps. At some point after bordeaux-threads-0.8.8 it decided to not load into non-threaded Lisps any more by design.

That meant that users of e.g. clisp without threads could no longer even use Drakma to fetch a web page, (recalling that the web has moved from http to https).

All libraries built on bordeaux-threads, assuming they want to continue supporting non-threaded Lisps, must therefore introduce conditionals around various bordeaux-threads function calls.

This commit makes that change to cl+ssl so that cl+ssl loads and works again on non-threaded clisp even with the newest bordeaux-threads.

Aside: clisp can be built with thread support. However that is not just beta, it is known to have race conditions because some data structures have not yet been made thread-safe. So the only correct variant of clisp is one built without thread support, which is the default build everywhere I've seen.